### PR TITLE
Support double-precision processing

### DIFF
--- a/katsdpimager/katsdpimager/fft.py
+++ b/katsdpimager/katsdpimager/fft.py
@@ -194,9 +194,15 @@ class Fft(accel.Operation):
 
 
 class GridToImageTemplate(object):
-    def __init__(self, command_queue, shape, padded_shape_src, padded_shape_dest):
-        self.shift_template = FftshiftTemplate(command_queue.context, np.complex64, 'float2')
-        self.fft_template = FftTemplate(command_queue, 2, shape, np.complex64,
+    def __init__(self, command_queue, shape, padded_shape_src, padded_shape_dest, dtype):
+        if dtype == np.complex64:
+            ctype = 'float2'
+        elif dtype == np.complex128:
+            ctype = 'double2'
+        else:
+            raise ValueError('Unhandled data type {}'.format(dtype))
+        self.shift_template = FftshiftTemplate(command_queue.context, dtype, ctype)
+        self.fft_template = FftTemplate(command_queue, 2, shape, dtype,
                                         padded_shape_src, padded_shape_dest)
 
     def instantiate(self, *args, **kwargs):

--- a/katsdpimager/katsdpimager/io.py
+++ b/katsdpimager/katsdpimager/io.py
@@ -169,7 +169,7 @@ def write_fits_grid(grid, image_parameters, filename):
         If the set of `polarizations` cannot be represented as a linear
         transform in the FITS header.
     """
-    grid = _split_array(grid, np.float32)
+    grid = _split_array(grid, image_parameters.dtype)
     grid = grid.transpose(3, 2, 0, 1)
 
     header = fits.Header()

--- a/katsdpimager/katsdpimager/parameters.py
+++ b/katsdpimager/katsdpimager/parameters.py
@@ -50,13 +50,15 @@ class ImageParameters(object):
         `pixels` are specified.
     polarizations : list
         List of polarizations that will appear in the image
+    dtype : {np.float32, np.complex64}
+        Floating-point type for image and grid
     pixel_size : Quantity or float, optional
         Angular size of a single pixel, or dimensionless to specify l or m
         size directly. If specified, `image_oversample` is ignored.
     pixels : int, optional
         Number of pixels in the image. If specified, `q_fov` is ignored.
     """
-    def __init__(self, q_fov, image_oversample, frequency, array, polarizations, pixel_size=None, pixels=None):
+    def __init__(self, q_fov, image_oversample, frequency, array, polarizations, dtype, pixel_size=None, pixels=None):
         self.wavelength = frequency.to(units.m, equivalencies=units.spectral())
         # Compute pixel size
         if pixel_size is None:
@@ -87,6 +89,8 @@ class ImageParameters(object):
                     recommended += 1
                 raise ValueError("Image size {} not supported - try {}".format(pixels, recommended))
         assert pixels % 2 == 0
+        self.dtype = np.dtype(dtype)
+        self.dtype_complex = np.promote_types(dtype, np.complex64)
         self.pixels = pixels
         self.image_size = self.pixel_size * pixels
         self.cell_size = self.wavelength / self.image_size

--- a/katsdpimager/katsdpimager/polarization.py
+++ b/katsdpimager/katsdpimager/polarization.py
@@ -61,7 +61,7 @@ STOKES_COEFF = np.array([
     [1, 1, 0, 0],
     [0, 0, 1, 1j],
     [0, 0, 1, -1j],
-    [1, -1, 0, 0]])
+    [1, -1, 0, 0]], np.complex64)
 
 
 @contextmanager
@@ -103,8 +103,9 @@ def polarization_matrix(outputs, inputs):
     # rounding errors. Round off anything that is close enough to a multiple.
     # In particular, tiny values will be flushed to zero, which is important
     # to apply_polarization_matrix.
-    Xr = np.round(4 * X) * 0.25
+    Xr = np.round(np.float32(4) * X) * np.float32(0.25)
     np.putmask(X, np.isclose(X, Xr), Xr)
+    assert X.dtype == np.complex64
     return X.T
 
 def apply_polarization_matrix(data, matrix):
@@ -158,8 +159,8 @@ def apply_polarization_matrix_weighted(data, weights, matrix):
     # negative zeros to positive zeros, so that the reciprocal
     # is +inf.
     with _np_seterr(divide='ignore'):
-        variance = 1.0 / np.abs(weights)
+        variance = np.reciprocal(np.abs(weights))
     weight_matrix = np.multiply(matrix, matrix.conj()).real  # Square of abs, element-wise
     variance = apply_polarization_matrix(variance, weight_matrix)
-    weights = 1.0 / variance
+    weights = np.reciprocal(variance)
     return data, weights


### PR DESCRIPTION
The incoming visibilities, weights and UV coordinates are kept in single
precision, since that's plenty given the noise levels. Accumulation in
the grid is done in double precision, as is the FFT.

This is unlikely to get used in production; it's just handy to support to
determine whether accuracy bugs are really bugs or just the limits of
precision.

This also caught a number of places where numpy calculations were being
promoted from single to double precision because Python float constants
were present.
