### PR TITLE
Include all files from conf/ subdirectories

### DIFF
--- a/katsdpcal/setup.py
+++ b/katsdpcal/setup.py
@@ -7,7 +7,7 @@ setup (
     author = "Laura Richter",
     author_email = "laura@ska.ac.za",
     packages = find_packages(),
-    package_data={'': ['conf/pipeline_params/*', 'conf/sky_models/*']},
+    package_data={'': ['conf/*/*']},
     include_package_data = True,
     scripts = [
         "scripts/reduction_script.py",


### PR DESCRIPTION
The merge of the rfi-flags branch broke katsdpcal packages because
conf/rfi_masks wasn't getting included.