### PR TITLE
Remove unneeded squeezes

### DIFF
--- a/katsdpcal/katsdpcal/calprocs.py
+++ b/katsdpcal/katsdpcal/calprocs.py
@@ -859,9 +859,9 @@ def k_fit(data,corrprod_lookup,chans=None,refant=0,chan_sample=1,**kwargs):
             A = np.array([good_chans, np.ones(len(good_chans))])
             delta_k[i] = np.linalg.lstsq(A.T,bp_phase)[0][0]/(2.*np.pi)
 
-        kdelay.append(np.squeeze(coarse_k + delta_k))
+        kdelay.append(coarse_k + delta_k)
 
-    return np.squeeze(kdelay)
+    return np.atleast_2d(kdelay)
 
 def kcross_fit(data,flags,chans=None,chan_ave=1):
     """


### PR DESCRIPTION
The k_fit method promises to return an array of shape
(num_pols, num_ants). If num_pols == 1, the first dimension is
currently squeezed away, leading to grief further down the line
when the K solutions are applied.

Remove all squeezes, as the coarse_k shape is guaranteed to be
(num_ants,) and kdelay is then a list of coarse_k's of length
num_pols. The np.atleast_2d() simply highlights this, but a straight
np.array(kdelay) could also have worked.