### PR TITLE
Apply border in which no CLEAN components can be added

### DIFF
--- a/katsdpimager/katsdpimager/imager_kernels/clean/update_tiles.mako
+++ b/katsdpimager/katsdpimager/imager_kernels/clean/update_tiles.mako
@@ -15,6 +15,9 @@ ${sample.define_sample(real_type, wgsx * wgsy)}
  * workgroup may be smaller than the tile (but exactly divide into it), in
  * which case each workitem reduces multiple elements before the
  * workgroup-wide reduction.
+ *
+ * The image_width and image_height are the indices of the last valid
+ * (non-border) pixels i.e. the true width and height less the border width.
  */
 KERNEL REQD_WORK_GROUP_SIZE(WGSX, WGSY, 1)
 void update_tiles(
@@ -23,6 +26,7 @@ void update_tiles(
     int image_pol_stride,
     int image_width,
     int image_height,
+    int image_border,
     GLOBAL T * RESTRICT tile_max,
     GLOBAL int2 * RESTRICT tile_pos,
     int tile_stride,
@@ -34,8 +38,8 @@ void update_tiles(
     sample priv;
     int tile_x = get_group_id(0) + tile_offset_x;
     int tile_y = get_group_id(1) + tile_offset_y;
-    int x0 = tile_x * TILEX + get_local_id(0);
-    int y0 = tile_y * TILEY + get_local_id(1);
+    int x0 = tile_x * TILEX + get_local_id(0) + image_border;
+    int y0 = tile_y * TILEY + get_local_id(1) + image_border;
     for (int y = 0; y < TILEY; y += WGSY)
         for (int x = 0; x < TILEX; x += WGSX)
         {

--- a/katsdpimager/katsdpimager/parameters.py
+++ b/katsdpimager/katsdpimager/parameters.py
@@ -240,18 +240,20 @@ Kernel support: {self.kernel_width} cells""".format(self=self)
 
 
 class CleanParameters(object):
-    def __init__(self, minor, loop_gain, major_gain, mode, psf_patch):
+    def __init__(self, minor, loop_gain, major_gain, mode, psf_patch, border):
         self.minor = minor
         self.loop_gain = loop_gain
         self.major_gain = major_gain
         self.mode = mode
         self.psf_patch = psf_patch
+        self.border = border
 
     def __str__(self):
         return """\
 Loop gain: {self.loop_gain}
 Major cycle gain: {self.major_gain}
 Max minor cycles: {self.minor}
-PSF patch size: {self.psf_patch}
-Peak function: {mode}""".format(
+PSF patch size: {self.psf_patch} pixels
+Peak function: {mode}
+Border: {self.border} pixels""".format(
             self=self, mode='I' if self.mode == clean.CLEAN_I else 'I^2+Q^2+U^2+V^2')

--- a/katsdpimager/scripts/imager.py
+++ b/katsdpimager/scripts/imager.py
@@ -88,6 +88,7 @@ def get_parser():
     group.add_argument('--major-gain', type=float, default=0.85, help='Fraction of peak to clean in each major cycle [%(default)s]')
     group.add_argument('--major', type=int, default=1, help='Major cycles [%(default)s]')
     group.add_argument('--minor', type=int, default=10000, help='Max minor cycles per major cycle [%(default)s]')
+    group.add_argument('--border', type=float, default=0.02, help='CLEAN border as a fraction of image size [%(default)s]')
     group.add_argument('--clean-mode', choices=['I', 'IQUV'], default='IQUV', help='Stokes parameters to consider for peak-finding [%(default)s]')
     group = parser.add_argument_group('Performance tuning options')
     group.add_argument('--vis-block', type=int, default=1048576, help='Number of visibilities to load and grid at a time [%(default)s]')
@@ -352,8 +353,9 @@ class ChannelParameters(object):
         else:
             raise ValueError('Unhandled --clean-mode {}'.format(args.clean_mode))
         psf_patch = min(args.psf_patch, self.image_p.pixels)
+        border = int(round(self.image_p.pixels * args.border))
         self.clean_p = parameters.CleanParameters(
-            args.minor, args.loop_gain, args.major_gain, clean_mode, psf_patch)
+            args.minor, args.loop_gain, args.major_gain, clean_mode, psf_patch, border)
 
     def log_parameters(self, suffix=''):
         log_parameters("Image parameters" + suffix, self.image_p)


### PR DESCRIPTION
Near the border of the image there are can be numeric instabilities due to
antialiasing, and placing components there can cause CLEAN not to
converge. A new --border option is added to control the size of a border
region, and the tiles used for peak-finding are restricted to (and
aligned with) the non-border areas.

The border region is not cropped from the final image. As far as I can
tell, this choice is consistent with wsclean. It allows large residuals
(such as uncleaned sources) to be spotted.

Closes [SR-289](https://skaafrica.atlassian.net/browse/SR-289).