### PR TITLE
Compute and display the normalized thermal RMS

### DIFF
--- a/katsdpimager/katsdpimager/imager_kernels/density_weights.mako
+++ b/katsdpimager/katsdpimager/imager_kernels/density_weights.mako
@@ -1,25 +1,43 @@
 <%include file="/port.mako"/>
+<%include file="atomic.mako"/>
+<%namespace name="wg_reduce" file="/wg_reduce.mako"/>
+
+<%wg_reduce:define_scratch type="float" size="${wgs_x * wgs_y}" scratch_type="scratch_t" allow_shuffle="${True}"/>
+<%wg_reduce:define_function type="float" size="${wgs_x * wgs_y}" function="reduce" scratch_type="scratch_t" broadcast="${False}" allow_shuffle="${True}"/>
 
 #define NPOLS ${num_polarizations}
 
 KERNEL REQD_WORK_GROUP_SIZE(${wgs_x}, ${wgs_y}, 1)
 void density_weights(
+    GLOBAL atomic_accum_float * RESTRICT sums,
     GLOBAL float * RESTRICT grid,
     int grid_row_stride,
     int grid_pol_stride,
     float a, float b)
 {
+    LOCAL_DECL scratch_t scratch;
     int u = get_global_id(0);
     int v = get_global_id(1);
+    int lid = get_local_id(1) * ${wgs_x} + get_local_id(0);
     int address = v * grid_row_stride + u;
     for (int pol = 0; pol < NPOLS; pol++)
     {
         float w = grid[address];
-        if (w != 0.0)
+        float d = (w != 0.0f) ? 1.0f / fma(a, w, b) : 0.0f;
+        if (pol == 0)
         {
-            w = 1.0 / fma(a, w, b);
-            grid[address] = w;
+            float dw = d * w;
+            float sum_w = reduce(w, lid, &scratch);
+            float sum_dw = reduce(dw, lid, &scratch);
+            float sum_d2w = reduce(d * dw, lid, &scratch);
+            if (lid == 0)
+            {
+                atomic_accum_float_add(&sums[0], sum_w);
+                atomic_accum_float_add(&sums[1], sum_dw);
+                atomic_accum_float_add(&sums[2], sum_d2w);
+            }
         }
+        grid[address] = d;
         address += grid_pol_stride;
     }
 }

--- a/katsdpimager/katsdpimager/imaging.py
+++ b/katsdpimager/katsdpimager/imaging.py
@@ -133,7 +133,7 @@ class Imaging(accel.OperationSequence):
 
     def finalize_weights(self):
         self.ensure_all_bound()
-        self._weights.finalize()
+        return self._weights.finalize()
 
     def clear_grid(self):
         self.ensure_all_bound()
@@ -259,7 +259,7 @@ class ImagingHost(object):
         self._weights.grid(uv, weights)
 
     def finalize_weights(self):
-        self._weights.finalize()
+        return self._weights.finalize()
 
     def clear_grid(self):
         self._grid.fill(0)

--- a/katsdpimager/scripts/imager.py
+++ b/katsdpimager/scripts/imager.py
@@ -186,8 +186,9 @@ def make_weights(queue, reader, rel_channel, imager, weight_type, vis_block):
                     bar.next(len(chunk.uv))
         else:
             bar.next(total)
-        imager.finalize_weights()
+        normalized_rms = imager.finalize_weights()
         queue.finish()
+    logger.info('Normalized thermal RMS: %g', normalized_rms)
 
 
 def make_dirty(queue, reader, rel_channel, name, field, imager, mid_w, vis_block, full_cycle=False):


### PR DESCRIPTION
This implements the recommendation from Brigg's thesis that imagers
should display this number, which indicates the relative increase in
noise compared to natural weighting.