### PR TITLE
Clean up activity sensor

### DIFF
--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -62,7 +62,7 @@ def get_tracks(data, ts, dump_period):
     ------
     data : dict
         Data buffer
-    ts : :class:`katsdptelstate.TelescopeState` object
+    ts : :class:`katsdptelstate.TelescopeState`
         The telescope state associated with this pipeline
     dump_period : float
         Dump period in seconds
@@ -88,7 +88,7 @@ def get_tracks(data, ts, dump_period):
     # Convert sequence of flags into segments and return the ones that are True
     all_tracking = CategoricalData(tracking, range(num_dumps + 1))
     all_tracking.remove_repeats()
-    return [segment for segment, track in all_tracking.segments() if track]
+    return [segment for (segment, track) in all_tracking.segments() if track]
 
 
 def get_solns_to_apply(s,ts,sol_list,logger,time_range=[]):


### PR DESCRIPTION
The get_tracks() function examines the receptor activity sensors in telstate and segments the data buffer into slices where receptors are tracking. The original algorithm is quite fragile if some receptors misbehave and end up with more segments than others due to overshoots. This results in the infamous "inconsistent tracks" warning that causes phase-ups and delay calibrations to fail.
    
Rewrite the function to use the same machinery as katdal to parse the activity sensors. Find segments where all receptors are definitely tracking to improve data quality.
    
The new algorithm is a bit more conservative, assigning fewer dumps to tracks (especially at the start of each segment) and also merging repeat activities. It is also slightly slower (13 ms vs 5 ms on 41 dumps with 8 receptors). This is tolerated for the sake of robustness and consistency with katdal.

I've done basic checks via run_katsdpcal_sim and verification of get_tracks in isolation.

This addresses JIRA ticket [MKAIV-615](https://skaafrica.atlassian.net/browse/MKAIV-615).