### PR TITLE
Fix imager nightly reports

### DIFF
--- a/katsdpimager/report-requirements.txt
+++ b/katsdpimager/report-requirements.txt
@@ -1,4 +1,4 @@
-aplpy==1.0
+aplpy==1.1.1
 astLib==0.8.0
 astro-kittens==0.3.3
 astro-tigger==1.3.3


### PR DESCRIPTION
They have been broken since the extra FITS keywords for describing
frequency were added, due to an aplpy bug. Fixed by creating a real
dimension of size 1 for the frequency axis. I've also done a bit of
cleanup on the report script to use information provided by
astropy.wcs.