### PR TITLE
Avoid pre-faulting the accumulation buffers

### DIFF
--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -1,0 +1,21 @@
+"""Tests for control module"""
+
+from multiprocessing import Process
+from nose.tools import assert_equal
+import numpy as np
+import katsdpcal.control as control
+
+
+def test_shared_empty():
+    def sender(a):
+        a[:] = np.outer(np.arange(5), np.arange(3))
+
+    a = control.shared_empty((5, 3), np.int32)
+    a.fill(0)
+    assert_equal((5, 3), a.shape)
+    assert_equal(np.int32, a.dtype)
+    p = Process(target=sender, args=(a,))
+    p.start()
+    p.join()
+    expected = np.outer(np.arange(5), np.arange(3))
+    np.testing.assert_equal(expected, a)


### PR DESCRIPTION
It used to take several minutes to allocate the buffers in large cases.
The buffers are now obtained directly from mmap, and are faulted in on
first being touched.

This won't work on Windows, because it doesn't use named shared buffers
or handle pickling, but we don't care about Windows.