### PR TITLE
Don't skip scans with fewer than three dumps

### DIFF
--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -244,13 +244,6 @@ def pipeline(data, ts, task_name='pipeline'):
             continue
         logger.info('  Tags:       {0}'.format(taglist,))
 
-        # if we only have one or two timestamps in the scan, ignore it
-        # (a single timestamp can happen when there is no slew between tracks
-        # so we catch the first dump of the next track).
-        if n_times < 3:
-            logger.info('Scan too short (only 1 or 2 timestamps) - ignored')
-            continue
-
         # ---------------------------------------
         # set up scan
         s = Scan(data, scan_slice, dump_period, n_ants, n_pols, ts.cal_bls_lookup, target,


### PR DESCRIPTION
Since activity parsing has improved with the introduction of the katdal sensor framework, there should be no need for this check. If problems recur we can always revisit this.

This will please commissioners who are forced to spend at least five dumps (i.e. more than 40 seconds for 8-second dumps) on target, which is unnecessarily long for phasing up on a strong source.
