### PR TITLE
Remove unnecessary code from katsdpcal/__init__.py

### DIFF
--- a/katsdpcal/katsdpcal/__init__.py
+++ b/katsdpcal/katsdpcal/__init__.py
@@ -11,24 +11,6 @@ param_dir = resource_filename(__name__, 'conf/pipeline_params')
 lsm_dir = resource_filename(__name__, 'conf/sky_models')
 rfi_dir = resource_filename(__name__, 'conf/rfi_masks')
 
-# force module to import pyrap before spead
-# (bug fix)
-try:
-    from pyrap.tables import table
-except:
-    print "Pyrap not found. Can't use MS simulator."
-    # fake table
-    class table:
-        pass
-
-import spead2
-from spead2 import recv
-from spead2 import send
-
-# default log level is INFO
-import logging
-logging.getLogger(__name__).setLevel(logging.INFO)
-
 # BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install
 try:

--- a/katsdpcal/katsdpcal/simulator.py
+++ b/katsdpcal/katsdpcal/simulator.py
@@ -5,9 +5,9 @@ Simulator class for HDF5 files produced by KAT-7 correlator,
 for testing of the MeerKAT pipeline.
 """
 
-from . import table
-from . import spead2
-from . import send
+from casacore import table
+import spead2
+from spead2 import send
 from .calprocs import get_reordering_nopol
 
 import katdal
@@ -360,7 +360,7 @@ class SimDataMS(table):
     """
     Simulated data class.
     Uses MS file to simulate MeerKAT pipeline data SPEAD stream and Telescope State,
-    subclassing pyrap table.
+    subclassing casacore table.
 
     Parameters
     ----------
@@ -870,7 +870,7 @@ class SimDataH5V3(katdal.H5DataV3):
 
     def close(self):
         """
-        Allows H5 simulator to emulate pyrap MS close function.
+        Allows H5 simulator to emulate casacore MS close function.
         (Does nothing)
         """
         pass
@@ -939,7 +939,7 @@ class SimDataH5V2(katdal.H5DataV2):
 
     def close(self):
         """
-        Allows H5 simulator to emulate pyrap MS close function.
+        Allows H5 simulator to emulate casacore MS close function.
         (Does nothing)
         """
         pass

--- a/katsdpcal/requirements.txt
+++ b/katsdpcal/requirements.txt
@@ -28,7 +28,7 @@ pkginfo
 ply                     # for katcp
 pyephem
 pyparsing
-python-casacore==2.0.0
+python-casacore
 python-dateutil
 pytz
 PyYAML==3.11

--- a/katsdpcal/scripts/create_test_data.py
+++ b/katsdpcal/scripts/create_test_data.py
@@ -2,7 +2,7 @@
 # ----------------------------------------------------------
 # Create sumulated data files from existing KAT-7 h5 files
 
-from pyrap import tables
+from casacore import tables
 import numpy as np
 import ephem
 import glob

--- a/katsdpcal/scripts/sim_l1_receive.py
+++ b/katsdpcal/scripts/sim_l1_receive.py
@@ -3,8 +3,7 @@
 # Simulate receiver for L1 data stream
 
 from katsdpcal.simulator import init_simdata, get_file_format, SimDataMS
-# import spead2 through katsdpcal to enforce import order (pyrap must be imported first)
-from katsdpcal import spead2
+import spead2
 
 from katsdptelstate import endpoint, ArgumentParser
 


### PR DESCRIPTION
It was a workaround for https://github.com/casacore/casacore/issues/243.
Since spead2 is no longer based on Boost.Python, the issue is no longer
of concern. It's also been fixed in casacore.

I also removed the override of the log level, since that should be up to
the user of the library, not the library itself.

I removed the version pin on python-casacore because docker-base now
provides a default version.