### PR TITLE
Skip chunking of solutions in apply

### DIFF
--- a/katsdpcal/katsdpcal/scan.py
+++ b/katsdpcal/katsdpcal/scan.py
@@ -455,7 +455,7 @@ class Scan(object):
 
     def apply(self, soln, vis):
         # set up more complex interpolation methods later
-        soln_values = da.from_array(soln.values, chunks=(1,) + soln.values.shape[1:])
+        soln_values = da.asarray(soln.values)
         if soln.soltype is 'G':
             # add empty channel dimension if necessary
             full_sol = soln_values[:, np.newaxis, :, :] \


### PR DESCRIPTION
Solutions were previously being split into separate chunks for every
point in time. This caused a lot more chunking than necessary when
applied to baseline-chunked data.

Instead, do no chunking of cal solutions, and let the operations inherit
the chunking of the data.