### PR TITLE
calprocs_dask.py

### DIFF
--- a/katsdpcal/katsdpcal/calprocs_dask.py
+++ b/katsdpcal/katsdpcal/calprocs_dask.py
@@ -8,7 +8,6 @@ rather than numpy arrays.
 """
 
 import logging
-from functools import wraps
 
 import numpy as np
 import dask.array as da
@@ -54,8 +53,8 @@ def stefcal(rawvis, num_ants, corrprod_lookup, weights=None, ref_ant=0,
 
     # Determine the output dtype, since the gufunc has two signatures
     if (np.can_cast(rawvis.dtype, np.complex64)
-        and np.can_cast(weights.dtype, np.float32)
-        and np.can_cast(init_gain, np.complex64)):
+            and np.can_cast(weights.dtype, np.float32)
+            and np.can_cast(init_gain, np.complex64)):
         dtype = np.complex64
     else:
         dtype = np.complex128


### PR DESCRIPTION
The bp_fit was normalising(rotating the combind solutions so that it has a mean of 0) the stefcal phase ambiguity across frequency ranter that across antennas, the normalisation  was changed to the last axis (antennas)

A test notebook can be found here:
https://drive.google.com/file/d/0B8fDNUwH4tM9elN3OEhZUkVIUUU/view?usp=sharing