### PR TITLE
Avoid crashing if there is no 'config' key in telstate

### DIFF
--- a/katsdpcal/scripts/run_cal.py
+++ b/katsdpcal/scripts/run_cal.py
@@ -245,8 +245,6 @@ def run(ts, stream_name, host, port,
         # don't print out the really long telescope state key values
         if keyval not in [stream_name + '_bls_ordering', 'cal_channel_freqs']:
             logger.info('%s : %s', keyval, ts[keyval])
-    logger.info('Telescope state config graph:')
-    log_dict(ts.config)
 
     # set up TS for pipeline use
     logger.info('Setting up Telescope State parameters for pipeline.')


### PR DESCRIPTION
With upcoming master controller changes, there will be no more global
configuration in config (instead it's all in per-node keys). This code
was already not very useful, as it predates the split of config into
separate keys per service.