### PR TITLE
Consolidate normalisation in bp_fit

### DIFF
--- a/katsdpcal/katsdpcal/calprocs_dask.py
+++ b/katsdpcal/katsdpcal/calprocs_dask.py
@@ -181,7 +181,6 @@ def wavg_full_t(data, flags, weights, solint, times=None):
 def bp_fit(data, corrprod_lookup, bp0=None, refant=0, normalise=True, **kwargs):
     """
     Fit bandpass to visibility data.
-    The bandpass phase is centred on zero.
 
     Parameters
     ----------
@@ -189,7 +188,7 @@ def bp_fit(data, corrprod_lookup, bp0=None, refant=0, normalise=True, **kwargs):
     bp0 : array of complex, shape(num_chans, num_pols, num_ants) or None
     corrprod_lookup : antenna mappings, for first then second antennas in bl pair
     refant : reference antenna
-    normalise : bool, True to normalise the bandpass amplitude
+    normalise : bool, True to normalise the bandpass amplitude and phase
 
     Returns
     -------
@@ -203,16 +202,15 @@ def bp_fit(data, corrprod_lookup, bp0=None, refant=0, normalise=True, **kwargs):
     # solve for the bandpass over the channel range
     bp = stefcal(data, n_ants, corrprod_lookup, num_iters=100,
                  init_gain=bp0, **kwargs)
-    # centre the phase on zero
-    angle = da.angle(bp)
-    base_angle = da.nanmin(angle, axis=0) - np.pi
-    # angle relative to base_angle, wrapped to range [0, 2pi], with
-    # some data point sitting at pi.
-    rel_angle = da.fmod(angle - base_angle, 2 * np.pi)
-    mid_angle = da.nanmean(rel_angle, axis=0) + base_angle
-    centre_rotation = da.exp(-1.0j * mid_angle)
-    rotated_bp = bp * centre_rotation
-    # normalise bandpasses by dividing through by the average
     if normalise:
-        rotated_bp /= (da.nansum(da.absolute(rotated_bp), axis=0) / n_chans)
-    return rotated_bp
+        # centre the phase on zero and scale the average amplitude to one
+        angle = da.angle(bp)
+        base_angle = da.nanmin(angle, axis=0) - np.pi
+        # angle relative to base_angle, wrapped to range [0, 2pi], with
+        # some data point sitting at pi.
+        rel_angle = da.fmod(angle - base_angle, 2 * np.pi)
+        mid_angle = da.nanmean(rel_angle, axis=0) + base_angle
+        centre_rotation = da.exp(-1.0j * mid_angle)
+        average_amplitude = da.nansum(da.absolute(bp), axis=0) / n_chans
+        bp *= centre_rotation / average_amplitude
+    return bp


### PR DESCRIPTION
The original bandpass fitter always centres the phase on zero and also optionally normalises the amplitude to an average of one (both as a function of frequency). The pipeline uses the default normalisation option of `True`, so both steps are typically performed for bpcal tags.

Some users prefer an unnormalised version of `bp_fit`, so rather combine the phase normalisation with the amplitude normalisation so that both are controlled by the same option. This has the added benefit of being faster, as the normalisation factor can be computed and then broadcast and applied once to the full set of gains.