### PR TITLE
Improve X11 authorisation documentation

### DIFF
--- a/katsdpcontim/README.rst
+++ b/katsdpcontim/README.rst
@@ -84,17 +84,20 @@ Run
 Authorise X11 connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may find it useful to run ``ObitView`` and AIPS TV utilities from inside the container.
-You'll need to authorise connections from the docker container to your X11 server.
+You may find it useful to run ``ObitView`` and ``AIPS TV`` utilities from inside the container.
+To achieve this you'll need to authorise connections from the docker container to your X11 server.
 
-On your machine, run the following to get the magic cookie:
+Run the following command on:
+
+1. **the docker host if you've SSH'd into it with X11 Forwarding**.
+2. your machine, if you're running the docker container locally
 
 .. code-block::
 
-    $ xauth list $DISPLAY
-    yourhostname/unix:0  MIT-MAGIC-COOKIE-1  abcdef1234567890abcdef1234567890
+    $ xauth -i -f ~/.Xauthority list $DISPLAY
+    hostname/unix:0  MIT-MAGIC-COOKIE-1  abcdef1234567890abcdef1234567890
 
-Then, inside the container, authorise the magic cooke as follows:
+Then, inside the container, authorise the magic cookie as follows:
 
 .. code-block::
 
@@ -106,7 +109,7 @@ You should then be able to run:
 
     $ ObitView
 
-and ObitView should open on your display.
+which should open on your display.
 
 
 Export katdal observation


### PR DESCRIPTION
Use `xauth -f ~/.Xauthority list $DISPLAY` on the docker host to get the
correct magic cookie.