### PR TITLE
Perform katdal selection before UV file creation

### DIFF
--- a/katsdpcontim/katsdpcontim/katsdpcontim/uv_export.py
+++ b/katsdpcontim/katsdpcontim/katsdpcontim/uv_export.py
@@ -28,6 +28,8 @@ def uv_export(kat_adapter, aips_path, nvispio=1024, kat_select=None):
         kat_select = {"scans": "track", "spw": 0}
 
     KA = kat_adapter
+    # Perform selection on the katdal object
+    KA.select(**kat_select)
 
     # UV file location variables
     with uv_factory(aips_path=aips_path, mode="w",
@@ -39,9 +41,6 @@ def uv_export(kat_adapter, aips_path, nvispio=1024, kat_select=None):
 
         # NX table rows
         nx_rows = []
-
-        # Perform selection on the katdal object
-        KA.select(**kat_select)
 
         for si, (u, v, w, time, baselines, source_id, vis) in KA.uv_scans():
 


### PR DESCRIPTION
The UV descriptor used to create the UV data file is derived from the katdal selection, so this needs
to be set before the `uv_factory` call.