### PR TITLE
Fix export in continuum_pipeline.py

### DIFF
--- a/katsdpcontim/katsdpcontim/katsdpcontim/util/__init__.py
+++ b/katsdpcontim/katsdpcontim/katsdpcontim/util/__init__.py
@@ -119,3 +119,12 @@ def task_factory(name, aips_cfg_file=None, **kwargs):
                 raise
 
     return task
+
+def fmt_bytes(nbytes):
+    """ Returns a human readable string, given the number of bytes """
+    for x in ['B','KB','MB','GB']:
+        if nbytes < 1024.0:
+            return "%3.1f%s" % (nbytes, x)
+        nbytes /= 1024.0
+
+    return "%.1f%s" % (nbytes, 'TB')

--- a/katsdpcontim/katsdpcontim/scripts/uv_export.py
+++ b/katsdpcontim/katsdpcontim/scripts/uv_export.py
@@ -48,8 +48,11 @@ with obit_context():
     aips_path = katdal_aips_path(KA, args.name, args.disk,
                                     args.aclass, args.seq, dtype="AIPS")
 
+    # Apply the katdal selection
+    KA.select(**args.select)
+
     # Perform export to the file
-    uv_export(KA, aips_path, nvispio=args.nvispio, kat_select=args.select)
+    uv_export(KA, aips_path, nvispio=args.nvispio)
 
     # Possibly perform baseline dependent averaging
     if args.blavg == True:


### PR DESCRIPTION
Within the continuum pipeline, katdal selection is used for two purposes:

1. To condition AIPS UV files with observation dimensions  and parameters.
2. Select a subset of the observation.

The two do not necessarily coincide. Within the pipeline, we often want to write all targets to the AIPS SU table into an AIPS UV file, but only want to write one scans worth of data. A katdal selection
for the scan results in one target which is unsuitable for conditioning the file...

This PR implements the (1) conditioning and (2) data selection in the correct places.