### PR TITLE
Get ArgumentParser from katsdpservices not katsdptelstate

### DIFF
--- a/katsdpcal/scripts/sim_data_stream.py
+++ b/katsdpcal/scripts/sim_data_stream.py
@@ -4,7 +4,8 @@
 
 import contextlib
 from katsdpcal.simulator import init_simdata
-from katsdptelstate import endpoint, ArgumentParser
+from katsdptelstate import endpoint
+from katsdpservices import ArgumentParser
 
 def parse_opts():
     parser = ArgumentParser(description = 'Simulate SPEAD data stream from H5 file')    

--- a/katsdpcal/scripts/sim_l1_receive.py
+++ b/katsdpcal/scripts/sim_l1_receive.py
@@ -5,7 +5,8 @@
 from katsdpcal.simulator import init_simdata, get_file_format, SimDataMS
 import spead2
 
-from katsdptelstate import endpoint, ArgumentParser
+from katsdptelstate import endpoint
+from katsdpservices import ArgumentParser
 
 import numpy as np
 import shutil

--- a/katsdpcal/scripts/sim_ts.py
+++ b/katsdpcal/scripts/sim_ts.py
@@ -4,7 +4,7 @@
 
 from katsdpcal import pipelineprocs, param_dir
 from katsdpcal.simulator import init_simdata
-from katsdptelstate import ArgumentParser
+from katsdpservices import ArgumentParser
 import os
 
 def parse_opts():


### PR DESCRIPTION
This is to allow the old copy of ArgumentParser to be removed from katsdptelstate.