### PR TITLE
Rename cal_product_B to indicate server number

### DIFF
--- a/katsdpcal/katsdpcal/calprocs.py
+++ b/katsdpcal/katsdpcal/calprocs.py
@@ -975,7 +975,6 @@ class CalSolution(object):
         self.soltype = soltype
         self.values = solvalues
         self.times = soltimes
-        self.ts_solname = 'cal_product_{}'.format(soltype)
 
     def __str__(self):
         """String representation of calibration solution to help identify it."""

--- a/katsdpcal/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/katsdpcal/pipelineprocs.py
@@ -84,7 +84,8 @@ COMPUTED_PARAMETERS = [
     Parameter('bls_lookup', 'list of baselines as indices into antennas', list),
     Parameter('channel_freqs', 'frequency of each channel in Hz, for this server', np.ndarray),
     Parameter('channel_freqs_all', 'frequency of each channel in Hz, for all servers', np.ndarray),
-    Parameter('channel_slice', 'Portion of channels handled by this server', slice)
+    Parameter('channel_slice', 'Portion of channels handled by this server', slice),
+    Parameter('product_names', 'Names to use in telstate for solutions', dict)
 ]
 
 
@@ -241,6 +242,13 @@ def finalise_parameters(parameters, telstate_l0, servers, server_id, rfi_filenam
         if bchan // (n_chans // servers) != (echan - 1) // (n_chans // servers):
             raise ValueError('{} channel range [{}, {}) spans multiple servers'
                              .format(prefix, bchan, echan))
+
+    parameters['product_names'] = {
+        'G': 'cal_product_G',
+        'K': 'cal_product_K',
+        'KCROSS': 'cal_product_KCROSS',
+        'B': 'cal_product_B{}'.format(server_id)
+    }
 
     # Sanity check: make sure we didn't set any parameters for which we don't
     # have a description.

--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -497,7 +497,7 @@ class TestCalDeviceServer(unittest.TestCase):
         assert_equal(1, len(report_files))
         assert_true(os.path.samefile(report, (yield self.get_sensor('report-last-path'))))
 
-        cal_product_B = self.telstate.get_range('cal_product_B', st=0)
+        cal_product_B = self.telstate.get_range('cal_product_B0', st=0)
         assert_equal(1, len(cal_product_B))
         ret_B, ret_B_ts = cal_product_B[0]
         assert_equal(np.complex64, ret_B.dtype)


### PR DESCRIPTION
To be generic, the names of products are now stored as
parameter['product_names']. CalSolution no longer stores its product
name to avoid needing to pass it to the constructor.