### PR TITLE
Eliminate info_sources telstate key

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -723,16 +723,6 @@ class Accumulator(object):
 
         return False
 
-    def _update_source_list(self, target_name, data_ts):
-        # TODO: will need updating for multi-server to avoid race conditions
-        try:
-            target_list = self.telstate_cb.get_range(
-                'info_sources', st=0, return_format='recarray')['value']
-        except KeyError:
-            target_list = []
-        if target_name not in target_list:
-            self.telstate_cb.add('info_sources', target_name, ts=data_ts)
-
     @trollius.coroutine
     def _accumulate(self, capture_block_id):
         """
@@ -808,10 +798,6 @@ class Accumulator(object):
                         if old_state is None:
                             start_idx = idx
                             logger.info('accumulating data from targets:')
-
-                        if old_state is None or new_state.target_name != old_state.target_name:
-                            # update source list if necessary
-                            self._update_source_list(new_state.target_name, data_ts)
 
                     # flush a batch if necessary
                     duration = (idx - start_idx) * self.int_time

--- a/katsdpcal/katsdpcal/report.py
+++ b/katsdpcal/katsdpcal/report.py
@@ -134,7 +134,7 @@ def write_bullet_if_present(report, table, var_text, var_name, transform=None):
     report.writeln('* {0}:  {1}'.format(var_text, value))
 
 
-def write_summary(report, ts, stream_name, parameters, st=None, et=None):
+def write_summary(report, ts, stream_name, parameters, targets, st=None, et=None):
     """
     Write observation summary information to report
 
@@ -148,6 +148,8 @@ def write_summary(report, ts, stream_name, parameters, st=None, et=None):
         name of the L0 data stream
     parameters : dict
         Pipeline parameters
+    targets : list of str
+        Target description strings (without duplicates)
     st : float, optional
         start time for reporting parameters, seconds
     et : float, optional
@@ -168,14 +170,11 @@ def write_summary(report, ts, stream_name, parameters, st=None, et=None):
 
     report.writeln('Source list:')
     report.writeln()
-    try:
-        target_list = ts.get_range('info_sources', st=0, return_format='recarray')['value']
-    except KeyError:
-        # key not present
+    target_names = list(set(katpoint.Target(target).name for target in targets))
+    for target in target_names:
+        report.writeln('* {0:s}'.format(target))
+    if not target_names:
         report.writeln('* Unknown')
-    else:
-        for target in target_list:
-            report.writeln('* {0:s}'.format(target))
 
     report.writeln()
 
@@ -1069,10 +1068,10 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
         cal_rst.writeln()
         cal_rst.writeln('Stream: {}'.format(stream_name))
         cal_rst.writeln()
-        write_summary(cal_rst, ts, stream_name, parameters, st=st, et=et)
+        unique_targets = list(set(av_corr['targets']))
+        write_summary(cal_rst, ts, stream_name, parameters, unique_targets, st=st, et=et)
 
         # Plot elevation vs time for reference antenna
-        unique_targets = list(set(av_corr['targets']))
         refant_index = parameters['refant_index']
         antennas = parameters['antennas']
         if len(av_corr['targets']) > 0:


### PR DESCRIPTION
It was being used to communicate a source list to the report writer, but
it had race conditions for multiple processes. The new report writer
already gets information about targets send through the queue, so uses
that instead.