### PR TITLE
Reduce memory usage for report writer

### DIFF
--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -49,6 +49,17 @@ def test_shared_empty():
     np.testing.assert_equal(expected, a)
 
 
+def test_concatenate_destroy():
+    arrays = [np.arange(6).reshape(2, 3),
+              np.arange(10, 16).reshape(2, 3)]
+    for axis in [-1, 0, 1]:
+        arg = list(arrays)
+        expected = np.concatenate(arrays, axis)
+        actual = control._concatenate_destroy(arg, axis)
+        np.testing.assert_array_equal(expected, actual)
+        assert_equal([], arg)
+
+
 class PingTask(control.Task):
     """Task class for the test. It receives numbers on a queue, and updates
     a sensor in response.


### PR DESCRIPTION
When concatenating the individual scan summaries into single arrays, a
new function is used which deletes each individual array as soon as it
is copied into the output array. This should roughly halve the memory
usage of the report writer.