### PR TITLE
Suppress katdal in requirements.txt if Python 3

### DIFF
--- a/katsdpimager/requirements.txt
+++ b/katsdpimager/requirements.txt
@@ -47,7 +47,7 @@ traceback2
 trollius
 unittest2
 
-git+ssh://git@github.com/ska-sa/katdal#egg=katdal
+git+ssh://git@github.com/ska-sa/katdal#egg=katdal; python_version<'3'
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint
 git+ssh://git@github.com/ska-sa/katsdpsigproc#egg=katsdpsigproc
 git+ssh://git@github.com/ska-sa/katsdptelstate#egg=katsdptelstate


### PR DESCRIPTION
Since ska-sa/katdal#150 katdal won't install on Python 3 anymore (which makes sense as it is Python 2.7 only). The katsdpimager package is tested on Python 3 as well, which then has broken requirements because of this katdal restriction.

As katdal is used in `loader_katdal` in katsdpimager but not in the tests, add a version qualifier to the requirement.