### PR TITLE
Switch to multi-stage build

### DIFF
--- a/katsdpimager/.dockerignore
+++ b/katsdpimager/.dockerignore
@@ -7,3 +7,4 @@ katsdpimager/_preprocess.so
 build
 doc/_build
 tests/report
+Dockerfile

--- a/katsdpimager/Dockerfile
+++ b/katsdpimager/Dockerfile
@@ -1,13 +1,23 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-build as build
+
+# Enable Python 2 ve
+ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"
 
 # Install dependencies
 RUN mkdir -p /tmp/install/katsdpimager
-COPY requirements.txt /tmp/install/requirements.txt
+COPY --chown=kat:kat requirements.txt /tmp/install/requirements.txt
 RUN install-requirements.py -d ~/docker-base/base-requirements.txt -d ~/docker-base/gpu-requirements.txt -r /tmp/install/requirements.txt
 
 # Install the current package
-COPY . /tmp/install/katsdpimager
-RUN cd /tmp/install/katsdpimager && \
-    python ./setup.py clean && \
-    pip install --no-deps .[ms,katdal] && \
-    pip check
+COPY --chown=kat:kat . /tmp/install/katsdpimager
+WORKDIR /tmp/install/katsdpimager
+RUN python ./setup.py clean
+RUN pip install --no-deps .[ms,katdal]
+RUN pip check
+
+#######################################################################
+
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-runtime
+
+COPY --from=build --chown=kat:kat /home/kat/ve /home/kat/ve
+ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"

--- a/katsdpimager/requirements.txt
+++ b/katsdpimager/requirements.txt
@@ -27,7 +27,7 @@ pbr
 pkgconfig==1.1.0
 progress==1.2
 py
-pybind11==2.2.0
+pybind11==2.2.3
 pycuda
 pyephem
 pytest


### PR DESCRIPTION
This shrinks the image size. pybind11 had to be upgraded to make it
compile, possibly due to changes in pip.