### PR TITLE
Fix labelling of the referance antenna in tables and plots

### DIFF
--- a/katsdpcal/katsdpcal/report.py
+++ b/katsdpcal/katsdpcal/report.py
@@ -1295,7 +1295,7 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
 
             # --------------------------------------------------------------------
             # label the reference antenna in the list of antennas
-            antenna_names = parameters['antenna_names']
+            antenna_names = list(parameters['antenna_names'])
             antenna_names[refant_index] += ', refant'
             name_width = len(antenna_names[refant_index])
             antenna_names = [name.ljust(name_width) for name in antenna_names]


### PR DESCRIPTION
Previously every time `make_cal_report` wrote a report it would append a refant label to the reference antenna in the antenna_names list. As antenna_names was only a shallow copy of the parameters[antenna_names] list, this resulted in an extra 'refant' being appended to list for every report written. This has poor readability and also breaks all the table alignments and formatting in the report when this label becomes very long.

This has been fixed by making the 'antenna_names' list a deep copy of the 'parameters[antenna_names]' list.