### PR TITLE
Correct HV delay using the median HV delay from all antennas

### DIFF
--- a/katsdpcal/katsdpcal/report.py
+++ b/katsdpcal/katsdpcal/report.py
@@ -244,7 +244,7 @@ def write_table_timecol(report, antenna_names, times, data, ave=False):
     data : :class:`np.ndarray`
         table data, shape (time, antenna)
     ave : bool
-        if True write the mean values in each column, else don't
+        if True write the median values in each column, else don't
     """
     n_entries = len(times) + 1
     col_width = 30
@@ -279,9 +279,9 @@ def write_table_timecol(report, antenna_names, times, data, ave=False):
         report.writeln()
 
     if ave:
-        report.write("MEAN".ljust(col_width + 1))
+        report.write("MEDIAN".ljust(col_width + 1))
         for di in data:
-            report.write(" {:<{}.3f}".format(np.nanmean(di), col_width + 1))
+            report.write(" {:<{}.3f}".format(np.nanmedian(di), col_width + 1))
         report.writeln()
 
     # table footer

--- a/katsdpcal/katsdpcal/scan.py
+++ b/katsdpcal/katsdpcal/scan.py
@@ -549,7 +549,7 @@ class Scan(object):
         elif soln.soltype in ['KCROSS_DIODE', 'KCROSS']:
             # average HV delay over all antennas
             channel_freqs = da.asarray(self.channel_freqs)
-            soln = da.nanmean(soln.values, axis=-1, keepdims=True)
+            soln = np.nanmedian(soln.values, axis=-1, keepdims=True)
             g_from_k = da.exp(2j * np.pi * soln[:, np.newaxis, :, :]
                               * channel_freqs[np.newaxis, :, np.newaxis, np.newaxis])
             g_from_k = da.tile(g_from_k, self.nant)


### PR DESCRIPTION
This is more robust to large outliers than using the mean HV delay.

Currently the HV delay correction will fail if there is one antenna with a bad/large delays estimate which biases the mean estimate of the delay. To correct this use the median HV delay of all antennas. 
This fix also requires that HV delays are corrected using the median across antennas during `calibrate_delays` 