### PR TITLE
Gracefully handle completely flagged channels

### DIFF
--- a/katsdpimager/scripts/imager.py
+++ b/katsdpimager/scripts/imager.py
@@ -464,7 +464,7 @@ def process_channel(dataset, args, start_channel,
                'PSF', 'weights', imager, mid_w, args.vis_block)
     # Normalization
     psf_peak = dirty[..., dirty.shape[1] // 2, dirty.shape[2] // 2]
-    if not np.all(psf_peak != 0):
+    if np.any(psf_peak == 0):
         logger.info('Skipping channel %d which has no usable data', channel)
         return
     scale = np.reciprocal(psf_peak)


### PR DESCRIPTION
Previously it would get a zero PSF and try to scale it up to have a peak
of 1.0, which lead to divide by zero and NaNs everywhere, which in turn
would crash the beam fitting.

Now if the PSF doesn't have a non-zero centre, it is assumed that all
the data has zero weight / is flagged.