### PR TITLE
Don't crash if there is no obs_activity yet

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -728,14 +728,14 @@ class Accumulator(object):
         try:
             activity, activity_time = self.telstate_cb_cal.get_range(
                 'obs_activity', et=data_ts, include_previous=True)[0]
-        except KeyError:
+        except (KeyError, IndexError):
             logger.info('No obs_activity found in telstate - ignoring dump')
             return None
         # Get target from telescope state if present (otherwise 'unknown')
         try:
             target = self.telstate.get_range('cbf_target', et=data_ts,
                                              include_previous=True)[0][0]
-        except KeyError:
+        except (KeyError, IndexError):
             logger.warning('No cbf_target found in telstate')
             target = ''
         # Extract name and tags from target description string


### PR DESCRIPTION
The `obs_activity` sensor is first set by CaptureSession in the observation script just after the SDP capture-init completes (typically a value of `idle` backdated to the start of the session). Since the sensor falls within a unique capture block view, it would not exist before then. If the cal pipeline sees data before this initial value, it would find the sensor but no relevant events, resulting in an
unhandled `IndexError` and therefore a crash.

Fix this by treating `IndexError` just like `KeyError`: no pertinent sensor data is available in either case. Also be prescient and fix the case of `cbf_target` in the same way (although it is much more unlikely to miss that sensor).

This will be eventually improved by katdal / katcal integration.

This addresses JIRA ticket [SR-1282](https://skaafrica.atlassian.net/browse/SR-1282).