### PR TITLE
Simplify mocking of spead2

### DIFF
--- a/katsdpcal/setup.py
+++ b/katsdpcal/setup.py
@@ -34,7 +34,7 @@ setup(
         "dask[array,distributed]>=0.17.0", "distributed>=1.12.0", "bokeh",
         "enum34", "manhole", "trollius", "futures", "attrs", "sortedcontainers",
         "katcp", "katpoint", "katdal", "katsdptelstate", "katsdpservices[asyncio,argparse]",
-        "katsdpsigproc", "spead2>=1.5.0", "docutils", "matplotlib>=2", "tornado<5"
+        "katsdpsigproc", "spead2>=1.8.0", "docutils", "matplotlib>=2", "tornado<5"
     ],
     tests_require=["mock", "nose"],
     use_katversion=True


### PR DESCRIPTION
Now uses spead2 "inproc" transport to replace the UDP streams with a
reliable transport, instead of trying to mock the interfaces.