### PR TITLE
Delete the working directory for imaging report

### DIFF
--- a/katsdpimager/Jenkinsfile.report
+++ b/katsdpimager/Jenkinsfile.report
@@ -45,6 +45,10 @@ catchError {
                                  reportDir: "$testdir/report",
                                  reportFiles: 'index.html',
                                  keepAll: true])
+            /* The working directly tends to get rather big - clean it out to
+             * prevent bloating the container.
+             */
+            deleteDir()
         }
     }
 }


### PR DESCRIPTION
The Jenkins agent containers tends to get quite bloated, an a big
contributor is the image reports. Now added a deleteDir step at the end
to nuke the working directory after publishing the results. This will
make debugging issues slightly harder, but should make disk full errors
less common.