### PR TITLE
Fix timestamps in L1 flags SPEAD stream

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -1119,6 +1119,7 @@ class Sender(Task):
         if self.flags_interface_address is None:
             self.flags_interface_address = ''
         self.int_time = self.telstate_l0['int_time']
+        self.sync_time = self.telstate_l0['sync_time']
         self.n_chans = self.telstate_l0['n_chans'] // n_servers
         self.l0_bls = np.asarray(self.telstate_l0['bls_ordering'])
         self.channel_slice = parameters['channel_slice']
@@ -1213,7 +1214,8 @@ class Sender(Task):
                         np.take(flags, self.ordering, axis=1, out=out_flags)
                         ig['flags'].value = out_flags
                         idx = self.buffers['dump_indices'][slot]
-                        ig['timestamp'].value = first_timestamp + idx * self.int_time
+                        ig['timestamp'].value = (
+                            first_timestamp + idx * self.int_time + self.sync_time)
                         ig['dump_index'].value = idx
                         tx.send_heap(ig.get_heap(data='all', descriptors='all'))
                         now = time.time()

--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -675,7 +675,9 @@ class TestCalDeviceServer(unittest.TestCase):
                 items = spead2.ItemGroup()
                 items.update(heap)
                 ts = items['timestamp'].value
-                assert_almost_equal(first_ts + j * self.telstate.sdp_l0test_int_time, ts)
+                expected_ts = (first_ts + j * self.telstate.sdp_l0test_int_time +
+                               self.telstate.sdp_l0test_sync_time)
+                assert_almost_equal(expected_ts, ts)
                 idx = items['dump_index'].value
                 assert_equal(j, idx)
                 assert_equal(i * self.n_channels // self.n_servers, items['frequency'].value)


### PR DESCRIPTION
It seems that these timestamps did not include the sync time in their calculation. Is this a bug?

There is also a case in test_control involving slew time that needs fixing in that case.