### PR TITLE
Allow vis, weights, flags to be user defined for a MockDataSet

### DIFF
--- a/katsdpcontim/katacomb/katacomb/mock_dataset.py
+++ b/katsdpcontim/katacomb/katacomb/mock_dataset.py
@@ -158,6 +158,7 @@ class MockDataSet(DataSet):
             argument and should have the following signature:
 
             .. code-block:: python
+
                 def my_vis(dataset, **kwargs):
                     shape = dataset.shape
                     my_data = kwargs['my_data']
@@ -167,7 +168,9 @@ class MockDataSet(DataSet):
             Data orthogonal to dataset can be passed in with ``functools.partial``
 
             .. code-block:: python
+
                 ds = MockDataSet(vis=partial(my_vis, my_data={...}))
+
         weights (optional): function
             Function from which the weights array is defined.
             Similar to vis, should create an ndarray of float32 values.


### PR DESCRIPTION
This adds the ability for user defined Visibilities, Weights and Flags in a katacomb MockDataSet . The user defines a function with a required 'shape' parameter and optional kwarg 'obj'. The function should generate an ndarray of the given shape. 'obj' is a keyword arg that allows the MockDataSet instance to be passed to the function.

I've made this a separate pull request so that you and I can discuss @sjperkins 