### PR TITLE
Revert "Flip sign of aips uvws"

### DIFF
--- a/katsdpcontim/katacomb/katacomb/katdal_adapter.py
+++ b/katsdpcontim/katacomb/katacomb/katdal_adapter.py
@@ -111,9 +111,6 @@ def aips_uvw(uvw, refwave):
     (AIPS Memo 117, Going AIPS, Obitdoc) which state that UVW coordinates
     should be in lightseconds.
 
-    AIPS uvw convention is ant2 - ant1 for visibilities in mvfv3 and mvfv4
-    files so we need to negate the output of katdal to convert to AIPS.
-
     Parameters
     ----------
     uvw : np.ndarray
@@ -126,7 +123,7 @@ def aips_uvw(uvw, refwave):
     np.ndarray
         AIPS UVW coordinates in wavelengths at the reference frequency
     """
-    return  -uvw / refwave
+    return uvw / refwave
 
 def katdal_uvw(uvw, refwave):
     """
@@ -146,7 +143,7 @@ def katdal_uvw(uvw, refwave):
     np.ndarray
         katdal UVW coordinates, in metres
     """
-    return refwave * -uvw
+    return refwave * uvw
 
 def aips_source_name(name):
     """ Truncates to length 16, padding with spaces """


### PR DESCRIPTION
Looks like I was wrong to flip the sign after all. Turns out I was using the wrong sign when simulating the visibilities, and doing the wrong comparison when checking my AIPS conversion against this one.

Thanks for picking this up @bmerry !

Reverts ska-sa/katsdppipelines#312