### PR TITLE
Enable stefcal to handle all zero visibilities

### DIFF
--- a/katsdpcal/katsdpcal/calprocs.py
+++ b/katsdpcal/katsdpcal/calprocs.py
@@ -203,13 +203,11 @@ def _stefcal_gufunc(rawvis, ant1, ant2, weights, ref_ant, init_gain, num_iters, 
     g_old = init_gain.copy()
 
     # Remove completely flagged antennas,
-    # where flags are indicated by a weight of zero
-    row_sum = np.zeros(num_ants, rawvis.dtype)
+    # where flags are indicated by a weighted visibility of zero
+    good_ant = np.ones(num_ants, np.bool_)
     for p in range(num_ants):
-        for i in range(num_ants):
-            row_sum[p] += R[p, i]
+        good_ant[p] = ~np.all(R[p] == 0j)
 
-    good_ant = row_sum != 0
     antlist = np.arange(num_ants)[good_ant]  # list of good antennas to iterate over.
     for n in range(num_iters[0]):
         for p in antlist:

--- a/katsdpcal/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/katsdpcal/test/test_calprocs.py
@@ -159,11 +159,10 @@ class TestStefcal(unittest.TestCase):
 
     def test_stefcal_all_zeros(self):
         """Test stefcal with visibilities set to zero"""
-        vis, weights, init_gain, bl_ant_list, gains = self.fake_data((10, 7,))
+        vis, weights, init_gain, bl_ant_list, gains = self.fake_data((10, 7))
         # Deliberately set the visibilities to zero in all baselines for one channel.
         # Set the gain to NaN in this channel
         # Have to unwrap it (in case it is a dask array) and rewrap it.
-        assert bl_ant_list[1, 0] != bl_ant_list[1, 1]  # Check that it isn't an autocorr
         vis = np.array(vis)
         vis[1] = 0j
         gains[1] = np.nan


### PR DESCRIPTION
Previously stefcal produces a `complex divide by zero` exception if visibilities to all baselines were zero but some of  weights for these visibilities were non-zero.  This case is now handled by only solving for gains if the weighted visibilities are non-zero, else the gain is set to NaN.