### PR TITLE
Work around CUDA 10 not handling mixed-precision FMAs

### DIFF
--- a/katsdpimager/katsdpimager/imager_kernels/degrid.mako
+++ b/katsdpimager/katsdpimager/imager_kernels/degrid.mako
@@ -29,9 +29,10 @@ DEVICE_FN float2 complex_mul(float2 a, float2 b)
 /// Computes a * b + c
 DEVICE_FN Complex Complex_mad(float2 a, Complex b, Complex c)
 {
+    Complex a_ = make_Complex(a.x, a.y);
     Complex out;
-    out.x = fma(a.x, b.x, fma(a.y, -b.y, c.x));
-    out.y = fma(a.x, b.y, fma(a.y, b.x, c.y));
+    out.x = fma(a_.x, b.x, fma(a_.y, -b.y, c.x));
+    out.y = fma(a_.x, b.y, fma(a_.y, b.x, c.y));
     return out;
 }
 

--- a/katsdpimager/katsdpimager/imager_kernels/grid.mako
+++ b/katsdpimager/katsdpimager/imager_kernels/grid.mako
@@ -28,8 +28,10 @@ DEVICE_FN float2 Complex_mul(float2 a, float2 b)
 DEVICE_FN Complex Complex_madc(float2 a, float2 b, Complex c)
 {
     Complex out;
-    out.x = fma(a.x, b.x, fma(a.y, b.y, c.x));
-    out.y = fma(a.x, -b.y, fma(a.y, b.x, c.y));
+    Complex a_ = make_Complex(a.x, a.y);
+    Complex b_ = make_Complex(b.x, b.y);
+    out.x = fma(a_.x, b_.x, fma(a_.y, b_.y, c.x));
+    out.y = fma(a_.x, -b_.y, fma(a_.y, b_.x, c.y));
     return out;
 }
 


### PR DESCRIPTION
When using fma with some float and some double arguments, it gives a
cryptic error message (it could also be a host compiler thing rather
than CUDA 10).

Fixed it by explicitly casting all the arguments to the higher
precision.