### PR TITLE
Make katsdpcal msgpack-telstate compliant

### DIFF
--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import threading
+import cPickle as pickle
 import katpoint
 
 import numpy as np
@@ -257,7 +258,7 @@ def shared_solve(telstate, parameters, solution_store, bchan, echan,
                     logger.warn('Solution is not of type :class:`~.CalSolution` or `~.CalSolutions`'
                                 ' and won\'t be stored in solution store')
         except Exception as error:
-            add_info(('Exception', error))
+            add_info(('Exception', pickle.dumps(error)))
             raise
         else:
             add_info(info)
@@ -269,7 +270,7 @@ def shared_solve(telstate, parameters, solution_store, bchan, echan,
         info = telstate[shared_key]
         logger.debug('Found shared key %s', shared_key)
         if info[0] == 'Exception':
-            raise info[1]
+            raise pickle.loads(info[1])
         elif info[0] == 'CalSolution':
             soltype, values, time = info[1:]
             if values is None:
@@ -451,7 +452,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 parameters['refant_index'] = best_refant_index
                 parameters['refant'] = parameters['antennas'][best_refant_index]
                 logger.info('Reference antenna set to %s', parameters['refant'].name)
-                ts.add('refant', parameters['refant'], immutable=True)
+                ts.add('refant', parameters['refant'].description, immutable=True)
                 s.refant = best_refant_index
 
         # run_t0 = time.time()

--- a/katsdpcal/katsdpcal/report.py
+++ b/katsdpcal/katsdpcal/report.py
@@ -1245,6 +1245,7 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             if refant_index is None:
                 refant = ts.get('refant')
                 if refant is not None:
+                    refant = katpoint.Antenna(refant)
                     refant_index = parameters['antenna_names'].index(refant.name)
                     parameters['refant'] = refant
                     parameters['refant_index'] = refant_index

--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -762,7 +762,7 @@ class TestCalDeviceServer(unittest.TestCase):
         yield self.shutdown_servers(180)
         yield self.assert_sensor_value('accumulator-capture-active', 0)
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
-        refant_name = telstate_cb_cal['refant'].name
+        refant_name = katpoint.Antenna(telstate_cb_cal['refant']).name
         assert_not_equal(self.antennas[worst_index], refant_name)
 
     def prepare_heaps(self, rs, n_times,


### PR DESCRIPTION
- Store 'refant' as an antenna description string, rather than an
  Antenna object.
- When passing an exception through telstate for shared_solve, pickle it
  so that it can pass through msgpack.