### PR TITLE
Fix parallactic angle correction from MS

### DIFF
--- a/katsdpimager/katsdpimager/loader_ms.py
+++ b/katsdpimager/katsdpimager/loader_ms.py
@@ -220,7 +220,7 @@ class LoaderMS(katsdpimager.loader_core.LoaderBase):
                             help='Data description ID to image [%(default)s]')
         parser.add_argument('--field', type=int, default=0,
                             help='Field to image [%(default)s]')
-        parser.add_argument('--pol-frame', choices=['sky', 'feed'],
+        parser.add_argument('--pol-frame', choices=['sky', 'feed'], default='sky',
                             help='Reference frame for polarization [%(default)s]')
         parser.add_argument('--uvw', choices=['casa', 'strict'], default='casa',
                             help='UVW sign convention [%(default)s]')
@@ -367,8 +367,8 @@ class LoaderMS(katsdpimager.loader_core.LoaderBase):
                     pointing_altaz = pointing_cirs.transform_to(altaz_frame)
                     pa = pointing_altaz.position_angle(pole_altaz)
                     feed_angle[:, i] = pa + self._antenna_angle[i]
-                feed_angle1 = feed_angle[inverse, antenna1]
-                feed_angle2 = feed_angle[inverse, antenna2]
+                feed_angle1 = feed_angle[inverse, antenna1].astype(np.float32)
+                feed_angle2 = feed_angle[inverse, antenna2].astype(np.float32)
             uvw = _getcol(self._main, 'UVW', start, nrows, 'm', units.m, 'uvw')[valid, ...]
             if not self._strict_uvw:
                 uvw = -uvw


### PR DESCRIPTION
It had broken at some point due to a dtype mismatch.

Also fixed the help for the option to list the default (previously it
defaulted to None, but that ended up being the same as 'sky'.