### PR TITLE
Add ability to specify phase ranges in phase plots.

### DIFF
--- a/katsdpcal/katsdpcal/plotting.py
+++ b/katsdpcal/katsdpcal/plotting.py
@@ -308,7 +308,7 @@ def plot_el_v_time(targets, times, elevations, title=None):
     return fig
 
 
-def plot_corr_uvdist(uvdist, data, freqlist=None, title=None, amp=False, pol=[0, 1], phase_range=None):
+def plot_corr_uvdist(uvdist, data, freqlist=None, title=None, amp=False, pol=[0, 1], phase_range=[-180, 180]):
     """
     Plots Amplitude and Phase vs UVdist
 
@@ -361,10 +361,7 @@ def plot_corr_uvdist(uvdist, data, freqlist=None, title=None, amp=False, pol=[0,
                 axes[p, 1].set_ylim(*lim)
         else:
             axes[p, 1].set_ylabel('Phase Pol_{0}'.format(pol[p]))
-            if phase_range:
-              axes[p, 1].set_ylim(phase_range[0], phase_range[-1])
-            else:
-              axes[p, 1].set_ylim(-180, 180)
+            axes[p, 1].set_ylim(phase_range[0], phase_range[-1])
         plt.setp(axes[p, 0].get_xticklabels(), visible=False)
         plt.setp(axes[p, 1].get_xticklabels(), visible=False)
 
@@ -418,7 +415,7 @@ def plot_delays(times, data, antenna_names=None, pol=[0, 1]):
     return fig
 
 
-def plot_phaseonly_spec(data, chan, antenna_names=None, freq_range=None, phase_range=None, title=None, pol=[0, 1]):
+def plot_phaseonly_spec(data, chan, antenna_names=None, freq_range=None, title=None, pol=[0, 1], phase_range=[-180, 180]):
     """ Plots spectrum of corrected data
 
     Parameters
@@ -431,14 +428,14 @@ def plot_phaseonly_spec(data, chan, antenna_names=None, freq_range=None, phase_r
         list of antenna/baseline names for plot legend, optional
     freq_range : list
         start and stop frequencies of the array, optional
-    phase_range : list, optional
-        start and stop phase ranges to plot, optional
     title : str, optional
         plot title
     amp : bool, optional
         plot only amplitudes if True, else plot amplitude and phase
     pol : list, optional
         list of polarisation descriptions
+    phase_range : list, optional
+        start and stop phase ranges to plot, optional
     """
     npols = data.shape[-2]
     nrows, ncols = 1, npols
@@ -450,10 +447,7 @@ def plot_phaseonly_spec(data, chan, antenna_names=None, freq_range=None, phase_r
     for p in range(npols):
         # plot full range amplitude plots
         p1 = axes[0, p].plot(chan, np.angle(data[..., p, :], deg=True), '.', ms=1)
-        if phase_range:
-          axes[0, p].set_ylim(phase_range[0], phase_range[-1])
-        else:
-          axes[0, p].set_ylim(-180, 180)
+        axes[0, p].set_ylim(phase_range[0], phase_range[-1])
         axes[0, p].set_ylabel('Phase Pol_{0}'.format(pol[p]))
         axes[0, p].set_xlabel('Channels')
 
@@ -470,7 +464,7 @@ def plot_phaseonly_spec(data, chan, antenna_names=None, freq_range=None, phase_r
     return fig
 
 
-def plot_spec(data, chan, antenna_names=None, freq_range=None, phase_range=None, title=None, amp=False, pol=[0, 1]):
+def plot_spec(data, chan, antenna_names=None, freq_range=None, title=None, amp=False, pol=[0, 1], phase_range=[-180, 180]):
     """ Plots spectrum of corrected data
 
     Parameters
@@ -512,10 +506,7 @@ def plot_spec(data, chan, antenna_names=None, freq_range=None, phase_range=None,
             # plot phase plots
             axes[p, 1].set_ylabel('Phase Pol_{0}'.format(pol[p]))
             axes[p, 1].plot(chan, np.angle(data[..., p, :], deg=True), '.', ms=1)
-            if phase_range:
-              axes[p, 1].set_ylim(phase_range[0], phase_range[-1])
-            else:
-              axes[p, 1].set_ylim(-180, 180)
+            axes[p, 1].set_ylim(phase_range[0], phase_range[-1])
         plt.setp(axes[p, 1].get_xticklabels(), visible=False)
 
     # set range limit
@@ -599,7 +590,7 @@ def amp_range(data):
     return low_lim, upper_lim
 
 
-def plot_corr_v_time(times, data, plottype='p', antenna_names=None, title=None, pol=[0, 1], phase_range=None):
+def plot_corr_v_time(times, data, plottype='p', antenna_names=None, title=None, pol=[0, 1], phase_range=[-180, 180]):
     """
     Plots amp/phase versus time
 
@@ -640,10 +631,7 @@ def plot_corr_v_time(times, data, plottype='p', antenna_names=None, title=None, 
             else:
                 p1 = axes[p, 0].plot(dates, np.angle(data_pol[:, chan, :], deg=True), '.')
                 axes[p, 0].set_ylabel('Phase Pol_{0}'.format(pol[p]))
-                if phase_range:
-                  axes[p, 0].set_ylim(phase_range[0], phase_range[-1])
-                else:
-                  axes[p, 0].set_ylim(-180, 180)
+                axes[p, 0].set_ylim(phase_range[0], phase_range[-1])
             # Reset the colour cycle, so that all channels have the same plot color
             axes[p, 0].set_prop_cycle(None)
             plt.setp(axes[p, 0].get_xticklabels(), visible=False)


### PR DESCRIPTION
This will allow to zoom into specific phase range in calibration report or in `phase_up_report` notebook/script I prepared with great help of @KimMcAlpine and which is in [katpulse](https://github.com/ska-sa/katpulse) repository.

I am not sure if you want to move position of `phase_range` to the end in function `plot_phaseonly_spec` and `plot_spec`. I thought having freq and phase range next to each other was nice but it might disrupt the workflow and create need for unnecessary updates.