### PR TITLE
katsdpimager: drop Python 2 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ katsdp.standardBuild(
     subdir: 'katsdpimager',
     cuda: true,
     python3: true,
+    python2: false,
     prepare_timeout: [time: 90, unit: 'MINUTES'],
     test_timeout: [time: 90, unit: 'MINUTES'])
 katsdp.mail(maintainer)

--- a/katsdpimager/Dockerfile
+++ b/katsdpimager/Dockerfile
@@ -1,7 +1,7 @@
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-build as build
 
-# Enable Python 2 ve
-ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"
+# Enable Python 3 ve
+ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
 # Install dependencies
 RUN mkdir -p /tmp/install/katsdpimager
@@ -17,7 +17,7 @@ RUN pip check
 
 #######################################################################
 
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-runtime:18.04
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-runtime
 
-COPY --from=build --chown=kat:kat /home/kat/ve /home/kat/ve
-ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"
+COPY --from=build --chown=kat:kat /home/kat/ve3 /home/kat/ve3
+ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"

--- a/katsdpimager/katsdpimager/beam.py
+++ b/katsdpimager/katsdpimager/beam.py
@@ -36,18 +36,19 @@ and its square root is
 .. include:: macros.rst
 """
 
-from __future__ import division, print_function, absolute_import
 import math
+
 import numpy as np
 import pkg_resources
 from astropy.modeling import models, fitting
 from astropy import units
 from katsdpsigproc import accel
-from katsdpimager import fft
 import katsdpimager.types
 
+from katsdpimager import fft
 
-class Beam(object):
+
+class Beam:
     """Gaussian synthesised beam model.
 
     Parameters
@@ -199,7 +200,7 @@ def convolve_beam(model, beam, out=None):
     return out
 
 
-class FourierBeamTemplate(object):
+class FourierBeamTemplate:
     """Multiply the Fourier transform of an image by the Fourier transform of a
     Gaussian beam model. The beam parameters must be in units of image pixels.
 
@@ -259,7 +260,7 @@ class FourierBeam(accel.Operation):
     def __init__(self, template, command_queue, image_shape, allocator=None):
         if len(image_shape) != 2:
             raise ValueError('image_shape must be 2D')
-        super(FourierBeam, self).__init__(command_queue, allocator=allocator)
+        super().__init__(command_queue, allocator=allocator)
         self.template = template
         self.image_shape = image_shape
         output_shape = (image_shape[0], image_shape[1] // 2 + 1)
@@ -304,7 +305,7 @@ class FourierBeam(accel.Operation):
         )
 
 
-class ConvolveBeamTemplate(object):
+class ConvolveBeamTemplate:
     """Template for device convolution of a model image with a Gaussian
     restoring beam, for a single polarization. Due to limitations in CUFFT,
     many parameters are folded into the template.
@@ -381,7 +382,7 @@ class ConvolveBeam(accel.OperationSequence):
             'image': ['fft:src', 'ifft:dest'],
             'fourier': ['fft:dest', 'ifft:src', 'fourier_beam:data']
         }
-        super(ConvolveBeam, self).__init__(
+        super().__init__(
             template.fft.command_queue, operations, compounds, allocator=allocator)
 
     @property

--- a/katsdpimager/katsdpimager/clean.py
+++ b/katsdpimager/katsdpimager/clean.py
@@ -15,14 +15,14 @@ minor cycles if the launch overheads become an issue.
 .. include:: macros.rst
 """
 
-from __future__ import division, print_function, absolute_import
 import math
+
 import numpy as np
-from katsdpimager import numba
 import katsdpsigproc.accel as accel
 import katsdpimager.types
 import pkg_resources
-from six.moves import range
+
+from katsdpimager import numba
 
 #: Use only Stokes I to find peaks
 CLEAN_I = 0
@@ -30,7 +30,7 @@ CLEAN_I = 0
 CLEAN_SUMSQ = 1
 
 
-class PsfPatchTemplate(object):
+class PsfPatchTemplate:
     """Examines a PSF to determine how big a PSF patch is required to
     enclosure all values above some threshold.
 
@@ -99,7 +99,7 @@ class PsfPatch(accel.Operation):
     def __init__(self, template, command_queue, shape, allocator=None):
         if shape[0] != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
-        super(PsfPatch, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         max_wg_x = accel.divup(shape[2], template.wgsx)
         max_wg_y = accel.divup(shape[1], template.wgsy)
         polarizations = accel.Dimension(template.num_polarizations, exact=True)
@@ -178,7 +178,7 @@ def power_to_metric(mode, power):
         raise ValueError('Invalid mode {}'.format(mode))
 
 
-class NoiseEstTemplate(object):
+class NoiseEstTemplate:
     """Robust estimation of the noise (as a standard deviation) in an image.
 
     The noise is estimated by computing the median absolute value via binary
@@ -253,7 +253,7 @@ class NoiseEst(accel.Operation):
             raise ValueError('Mismatch in number of polarizations')
         if border * 2 >= min(image_shape[1], image_shape[2]):
             raise ValueError('Border must be less than half the image size')
-        super(NoiseEst, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self._num_tiles_x = accel.divup(image_shape[2] - 2 * border, template.tilex)
         self._num_tiles_y = accel.divup(image_shape[1] - 2 * border, template.tiley)
         self.template = template
@@ -326,7 +326,7 @@ class NoiseEst(accel.Operation):
         return metric_to_power(self.template.mode, low) * 1.48260222
 
 
-class _UpdateTilesTemplate(object):
+class _UpdateTilesTemplate:
     """Operation template to compute the peak (including location) for each
     tile intersecting a window.
 
@@ -400,7 +400,7 @@ class _UpdateTiles(accel.Operation):
             raise ValueError('Mismatch in number of polarizations')
         if border * 2 >= min(image_shape[1], image_shape[2]):
             raise ValueError('Border must be less than half the image size')
-        super(_UpdateTiles, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         num_tiles_x = accel.divup(image_shape[2] - 2 * border, template.tilex)
         num_tiles_y = accel.divup(image_shape[1] - 2 * border, template.tiley)
         image_width = accel.Dimension(image_shape[2])
@@ -447,7 +447,7 @@ class _UpdateTiles(accel.Operation):
                 local_size=(self.template.wgsx, self.template.wgsy))
 
 
-class _FindPeakTemplate(object):
+class _FindPeakTemplate:
     """Find the global peak from per-tile peaks.
 
     Parameters
@@ -515,7 +515,7 @@ class _FindPeak(accel.Operation):
     def __init__(self, template, command_queue, image_shape, tile_shape, allocator=None):
         if image_shape[0] != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
-        super(_FindPeak, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self.template = template
         image_dims = [accel.Dimension(image_shape[0], exact=True),
                       accel.Dimension(image_shape[1]),
@@ -553,7 +553,7 @@ class _FindPeak(accel.Operation):
             local_size=(self.template.wgsx, self.template.wgsy))
 
 
-class _SubtractPsfTemplate(object):
+class _SubtractPsfTemplate:
     """Subtract a multiple of the point spread function from the dirty image,
     and add a corresponding single pixel to the model image.
 
@@ -626,7 +626,7 @@ class _SubtractPsf(accel.Operation):
         match `template`
     """
     def __init__(self, template, command_queue, loop_gain, image_shape, psf_shape, allocator=None):
-        super(_SubtractPsf, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         pol_dim = accel.Dimension(template.num_polarizations, exact=True)
         if image_shape[0] != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
@@ -687,7 +687,7 @@ class _SubtractPsf(accel.Operation):
             local_size=(self.template.wgsx, self.template.wgsy))
 
 
-class CleanTemplate(object):
+class CleanTemplate:
     """Composite template for the CLEAN minor cycles.
 
     Parameters
@@ -787,7 +787,7 @@ class Clean(accel.OperationSequence):
             'peak_pos': ['find_peak:peak_pos'],
             'peak_pixel': ['find_peak:peak_pixel', 'subtract_psf:peak_pixel']
         }
-        super(Clean, self).__init__(command_queue, ops, compounds, allocator=allocator)
+        super().__init__(command_queue, ops, compounds, allocator=allocator)
         peak_value = self.slots['peak_value']
         peak_pos = self.slots['peak_pos']
         self._peak_value_host = accel.HostArray(
@@ -926,7 +926,7 @@ def _tile_peak(y0, x0, y1, x1, image, mode, zero):
     return best_pos, best_value
 
 
-class CleanHost(object):
+class CleanHost:
     """CPU-only equivalent to :class:`Clean`. The class keeps references to
     the provided arrays, and only examines modifies them when :meth:`reset`
     or :meth:`__call__` is invoked.

--- a/katsdpimager/katsdpimager/fft.py
+++ b/katsdpimager/katsdpimager/fft.py
@@ -3,13 +3,12 @@
 .. include:: macros.rst
 """
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import pkg_resources
 import skcuda.fft
 from katsdpsigproc import accel
+
 import katsdpimager.types
-from six.moves import zip
 
 #: Forward FFT
 FFT_FORWARD = 0
@@ -17,7 +16,7 @@ FFT_FORWARD = 0
 FFT_INVERSE = 1
 
 
-class _Gpudata(object):
+class _Gpudata:
     """Adapter to allow skcuda.fft to work with managed memory
     allocations. Add it as a `gpudata` member on an arbitrary object, to allow
     that object to be passed instead of a :py:class`pycuda.gpuarray.GPUArray`.
@@ -36,7 +35,7 @@ class _Gpudata(object):
         return int(self) != int(other)
 
 
-class _GpudataWrapper(object):
+class _GpudataWrapper:
     """Forwarding wrapper around a :py:class:`katsdpsigproc.accel.SVMArray` or
     :py:class:`katsdpsigproc.accel.DeviceArray` that allows it to be passed
     to skcuda.fft.
@@ -54,7 +53,7 @@ class _GpudataWrapper(object):
         return getattr(self._wrapped, attr)
 
 
-class FftshiftTemplate(object):
+class FftshiftTemplate:
     """Operation template for the equivalent of :py:meth:`np.fft.fftshift` on
     the device, in-place. The last two dimensions are shifted, and these
     dimensions must have even size. Because the size is even, this operation
@@ -113,7 +112,7 @@ class Fftshift(accel.Operation):
         if the first two dimensions in `shape` are not even
     """
     def __init__(self, template, command_queue, shape, allocator=None):
-        super(Fftshift, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self.template = template
         self.kernel = template.program.get_kernel('fftshift')
         if shape[-1] % 2 != 0 or shape[-2] % 2 != 0:
@@ -146,7 +145,7 @@ class Fftshift(accel.Operation):
         )
 
 
-class FftTemplate(object):
+class FftTemplate:
     r"""Operation template for a forward or reverse FFT. The transformation is
     done over the last N dimensions, with the remaining dimensions for batching
     multiple arrays to be transformed. Dimensions before the first N must have
@@ -236,7 +235,7 @@ class Fft(accel.Operation):
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, mode, allocator=None):
-        super(Fft, self).__init__(template.command_queue, allocator)
+        super().__init__(template.command_queue, allocator)
         self.template = template
         src_shape = list(template.shape)
         dest_shape = list(template.shape)

--- a/katsdpimager/katsdpimager/imaging.py
+++ b/katsdpimager/katsdpimager/imaging.py
@@ -1,13 +1,13 @@
 """Top-level objects for accelerated imaging, that glue the lower-level
 objects together."""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 from katsdpsigproc import accel
+
 from . import grid, predict, weight, image, clean
 
 
-class ImagingTemplate(object):
+class ImagingTemplate:
     """Template holding all the other templates for imaging."""
 
     def __init__(self, command_queue, array_parameters, image_parameters,
@@ -123,7 +123,7 @@ class Imaging(accel.OperationSequence):
         # early on while setting up weights_grid.
         # TODO: could alias noise_est:rank with something, since it's only
         # needed at the start of the minor cycles (it is small though).
-        super(Imaging, self).__init__(
+        super().__init__(
             template.command_queue, operations, compounds, allocator=allocator)
 
     def __call__(self):
@@ -237,7 +237,7 @@ class Imaging(accel.OperationSequence):
         return self._clean(psf_patch, threshold)
 
 
-class ImagingHost(object):
+class ImagingHost:
     """Host-only equivalent to :class:`Imaging`."""
 
     def __init__(self, image_parameters, weight_parameters, grid_parameters, clean_parameters):

--- a/katsdpimager/katsdpimager/io.py
+++ b/katsdpimager/katsdpimager/io.py
@@ -1,11 +1,12 @@
 """Miscellaneous file format routines"""
 
-from __future__ import division, print_function, absolute_import
+import logging
+
 import numpy as np
 import astropy.units as units
 import astropy.io.fits as fits
+
 import katsdpimager.polarization as polarization
-import logging
 
 
 _logger = logging.getLogger(__name__)

--- a/katsdpimager/katsdpimager/loader.py
+++ b/katsdpimager/katsdpimager/loader.py
@@ -1,6 +1,5 @@
 """Data loading frontend"""
 
-from __future__ import division, print_function, absolute_import
 import warnings
 
 

--- a/katsdpimager/katsdpimager/loader_core.py
+++ b/katsdpimager/katsdpimager/loader_core.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 """Base classes used by loader modules"""
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import astropy.units as units
+
 from . import parameters
-from six.moves import range
 
 
-class LoaderBase(object):
+class LoaderBase:
     def __init__(self, filename, options):
         """Open the file"""
         self.filename = filename

--- a/katsdpimager/katsdpimager/loader_katdal.py
+++ b/katsdpimager/katsdpimager/loader_katdal.py
@@ -6,17 +6,18 @@ on correlation products while katsdpimager works on baselines, so some
 conversion is needed.
 """
 
-from __future__ import division, print_function, absolute_import
 import argparse
 import logging
 import itertools
 import math
+import urllib
+
 import katsdpimager.loader_core
 import katdal
 import numpy as np
 import astropy.units as units
+
 from . import polarization
-from six.moves import range, urllib
 
 
 _logger = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ class LoaderKatdal(katsdpimager.loader_core.LoaderBase):
                 return idx
 
     def __init__(self, filename, options):
-        super(LoaderKatdal, self).__init__(filename, options)
+        super().__init__(filename, options)
         parser = argparse.ArgumentParser(
             prog='katdal options',
             usage='katdal options: [-i subarray=N] [-i spw=M] ...')

--- a/katsdpimager/katsdpimager/loader_ms.py
+++ b/katsdpimager/katsdpimager/loader_ms.py
@@ -1,16 +1,16 @@
 """Data loading backend for CASA Measurement Sets."""
 
-from __future__ import division, print_function, absolute_import
 import argparse
 import logging
-import katsdpimager.loader_core
+
 import casacore.tables
 import casacore.quanta
 import numpy as np
 import astropy.units as units
 import astropy.time
 import astropy.coordinates
-from six.moves import range
+
+import katsdpimager.loader_core
 
 
 _logger = logging.getLogger(__name__)
@@ -210,7 +210,7 @@ def _fix_cache_size(table, column):
 
 class LoaderMS(katsdpimager.loader_core.LoaderBase):
     def __init__(self, filename, options):
-        super(LoaderMS, self).__init__(filename, options)
+        super().__init__(filename, options)
         parser = argparse.ArgumentParser(
             prog='Measurement set options',
             usage='Measurement set options: [-i data=COLUMN] [-i field=FIELD] ...')

--- a/katsdpimager/katsdpimager/numba.py
+++ b/katsdpimager/katsdpimager/numba.py
@@ -1,6 +1,5 @@
 """Wrapper around numba that either uses numba, or provides a no-op jit
 function."""
-from __future__ import division, print_function, absolute_import
 
 try:
     from numba import jit

--- a/katsdpimager/katsdpimager/parameters.py
+++ b/katsdpimager/katsdpimager/parameters.py
@@ -5,10 +5,11 @@ specifying any specific units.
 Most formulae are taken from SKA-TEL-SDP-0000003.
 """
 
-from __future__ import division, print_function, absolute_import
-import astropy.units as units
 import math
+
+import astropy.units as units
 import numpy as np
+
 import katsdpimager.types
 from . import clean, weight
 
@@ -24,7 +25,7 @@ def is_smooth(x):
     return x == 1
 
 
-class ArrayParameters(object):
+class ArrayParameters:
     """Physical attributes of an interferometric array."""
     def __init__(self, antenna_diameter, longest_baseline):
         assert antenna_diameter.unit.physical_type == 'length'
@@ -33,7 +34,7 @@ class ArrayParameters(object):
         self.longest_baseline = longest_baseline
 
 
-class ImageParameters(object):
+class ImageParameters:
     """Physical properties associated with an image. At present, only
     single-frequency images are supported.
 
@@ -171,7 +172,7 @@ def w_slices(image_parameters, max_w, eps_w, kernel_width, antialias_width=0):
     return hi
 
 
-class WeightParameters(object):
+class WeightParameters:
     """Parameters affecting imaging weight calculations.
 
     Parameters
@@ -197,7 +198,7 @@ class WeightParameters(object):
         return 'Image weights: ' + ans
 
 
-class GridParameters(object):
+class GridParameters:
     """Parameters affecting gridding algorithm.
 
     Parameters
@@ -240,7 +241,7 @@ Antialiasing support: {self.antialias_width} cells
 Kernel support: {self.kernel_width} cells""".format(self=self)
 
 
-class CleanParameters(object):
+class CleanParameters:
     def __init__(self, minor, loop_gain, major_gain, threshold, mode,
                  psf_cutoff, psf_limit, border):
         self.minor = minor

--- a/katsdpimager/katsdpimager/polarization.py
+++ b/katsdpimager/katsdpimager/polarization.py
@@ -28,8 +28,8 @@ different from those used in FITS:
 .. py:data:: STOKES_YY
 """
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
+
 
 STOKES_I = 1
 STOKES_Q = 2

--- a/katsdpimager/katsdpimager/predict.py
+++ b/katsdpimager/katsdpimager/predict.py
@@ -14,13 +14,11 @@ The visibilities are assumed to have already been passed through the
 .. include:: macros.rst
 """
 
-from __future__ import division, print_function, absolute_import
 import logging
 
 import numpy as np
 import pkg_resources
 from astropy import units
-
 from katsdpsigproc import accel, tune
 
 from . import polarization, types, grid, parameters, numba
@@ -100,7 +98,7 @@ def _uvw_scale_bias(image_parameters, grid_parameters):
     return uv_scale, w_scale, w_bias
 
 
-class PredictTemplate(object):
+class PredictTemplate:
     """Predict visibilities from a sky model by directly evaluating the RIME.
 
     Parameters
@@ -219,8 +217,8 @@ class Predict(grid.VisOperation):
                  max_vis, max_sources, allocator=None):
         if len(image_parameters.polarizations) != template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
-        super(Predict, self).__init__(command_queue, template.num_polarizations, max_vis,
-                                      allocator)
+        super().__init__(command_queue, template.num_polarizations, max_vis,
+                         allocator)
         self.template = template
         pol_dim = accel.Dimension(template.num_polarizations, exact=True)
         sources_dim = max(1, max_sources)   # Cannot allocate 0-byte buffer

--- a/katsdpimager/katsdpimager/progress.py
+++ b/katsdpimager/katsdpimager/progress.py
@@ -7,17 +7,17 @@ This wraps the :py:mod:`progress` module to add certain enhancements:
 - A fallback implementation is used when stderr is not a TTY.
 """
 
-from __future__ import division, print_function, absolute_import
-import progress
-import progress.bar
 import sys
 import functools
 from contextlib import contextmanager
 
+import progress
+import progress.bar
 
-class NoTtyMixin(object):
+
+class NoTtyMixin:
     def __init__(self, *args, **kwargs):
-        super(NoTtyMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._written_length = 0
 
     def update(self):
@@ -54,7 +54,7 @@ def make_progressbar(name, *args, **kwargs):
     return bar
 
 
-class RunOnce(object):
+class RunOnce:
     """Wrapper callable that calls the wrapped function only the first time."""
     def __init__(self, wrapped):
         self.wrapped = wrapped

--- a/katsdpimager/katsdpimager/sky_model.py
+++ b/katsdpimager/katsdpimager/sky_model.py
@@ -5,12 +5,10 @@ At present the only file format supported is a katpoint catalogue file, but
 other formats (e.g. Tigger) may be added later.
 """
 
-from __future__ import print_function, division, absolute_import
-
 import itertools
 import logging
+import urllib
 
-from six.moves import urllib
 import numpy as np
 import astropy.units as units
 import katpoint
@@ -19,7 +17,7 @@ import katpoint
 logger = logging.getLogger(__name__)
 
 
-class SkyModel(object):
+class SkyModel:
     """A sky model which can be used to generate images at specified frequencies.
 
     This is an abstract base class.

--- a/katsdpimager/katsdpimager/test/test_beam.py
+++ b/katsdpimager/katsdpimager/test/test_beam.py
@@ -1,12 +1,11 @@
 """Tests for :py:mod:`katsdpimager.beam`"""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import scipy.signal
 from astropy.modeling import models
-from katsdpimager import beam
 from katsdpsigproc.test.test_accel import device_test, cuda_test
-from six.moves import range
+
+from katsdpimager import beam
 
 
 def convolve_beam_reference(model, beam):
@@ -29,7 +28,7 @@ def convolve_beam_reference(model, beam):
     return out
 
 
-class TestConvolveBeam(object):
+class TestConvolveBeam:
     """Test both host and device beam convolution functions"""
     def setup(self):
         self.beam = beam.Beam(models.Gaussian2D(amplitude=3.5, x_mean=0.0, y_mean=0.0,

--- a/katsdpimager/katsdpimager/test/test_clean.py
+++ b/katsdpimager/katsdpimager/test/test_clean.py
@@ -1,15 +1,14 @@
 """Tests for :py:mod:`katsdpimager.clean`"""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 import scipy.signal
-from .. import clean
 from katsdpsigproc.test.test_accel import device_test
 from nose.tools import assert_equal, assert_greater_equal
-from six.moves import range
+
+from .. import clean
 
 
-class _TestPsfPatchBase(object):
+class _TestPsfPatchBase:
     """Tests for :class:`~katsdpimager.clean.PsfPatch` and :class:`~katsdpimager.clean.psf_patch_host."""   # noqa: E501
     def test_peak_only(self):
         assert_equal((4, 1, 1), self._test())
@@ -63,7 +62,7 @@ class TestPsfPatchHost(_TestPsfPatchBase):
         return clean.psf_patch_host(self.psf_host, threshold, limit)
 
 
-class TestClean(object):
+class TestClean:
     @classmethod
     def _make_psf(cls, size):
         """Creates a dummy PSF as a Gaussian plus random noise"""

--- a/katsdpimager/katsdpimager/test/test_fft.py
+++ b/katsdpimager/katsdpimager/test/test_fft.py
@@ -1,7 +1,5 @@
 """Tests for :mod:`katsdpimager.fft`"""
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import katsdpsigproc.accel as accel
 from katsdpsigproc.test.test_accel import device_test, cuda_test
@@ -10,7 +8,7 @@ from .. import fft
 from .utils import RandomState
 
 
-class TestFftshift(object):
+class TestFftshift:
     @classmethod
     def pad_dimension(cls, dim, extra):
         """Modifies `dim` to have at least `extra` padding"""
@@ -48,7 +46,7 @@ class TestFftshift(object):
         np.testing.assert_equal(expected, actual)
 
 
-class TestFft(object):
+class TestFft:
     @device_test
     @cuda_test
     def test_forward(self, context, command_queue):

--- a/katsdpimager/katsdpimager/test/test_grid.py
+++ b/katsdpimager/katsdpimager/test/test_grid.py
@@ -1,13 +1,11 @@
 """Tests for :mod:`katsdpimager.grid`."""
 
-from __future__ import division, print_function, absolute_import
+from unittest import mock
 
 import numpy as np
 import astropy.units as units
 import katsdpsigproc.accel as accel
 from katsdpsigproc.test.test_accel import device_test, force_autotune
-import mock
-from six.moves import range, zip
 
 from .. import parameters, polarization, grid
 from .utils import RandomState
@@ -24,7 +22,7 @@ def _middle(array, shape):
     return array[tuple(index)]
 
 
-class BaseTest(object):
+class BaseTest:
     def setup(self):
         pixels = 256
         grid_cover = 180

--- a/katsdpimager/katsdpimager/test/test_image.py
+++ b/katsdpimager/katsdpimager/test/test_image.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`katsdpimager.image`"""
 
-from __future__ import division, print_function, absolute_import
 import math
 
 import numpy as np
@@ -10,7 +9,7 @@ from .. import image
 from .utils import RandomState
 
 
-class TestLayerToImage(object):
+class TestLayerToImage:
     @device_test
     def test(self, context, command_queue):
         slices = 3
@@ -45,7 +44,7 @@ class TestLayerToImage(object):
         np.testing.assert_allclose(expected, actual, 1e-4)
 
 
-class TestImageToLayer(object):
+class TestImageToLayer:
     @device_test
     def test(self, context, command_queue):
         # Since LayerToImage is tested from first principles, we just check
@@ -88,7 +87,7 @@ class TestImageToLayer(object):
         np.testing.assert_allclose(expected[1], actual[1], 1e-4)
 
 
-class TestScale(object):
+class TestScale:
     @device_test
     def test(self, context, command_queue):
         shape = (4, 123, 234)

--- a/katsdpimager/katsdpimager/test/test_polarization.py
+++ b/katsdpimager/katsdpimager/test/test_polarization.py
@@ -1,12 +1,12 @@
 """Tests for :py:mod:`katsdpimager.polarization`."""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 from nose.tools import assert_raises
+
 import katsdpimager.polarization as polarization
 
 
-class TestPolarizationMatrix(object):
+class TestPolarizationMatrix:
     """Tests for :py:func:`katsdpimager.polarization.polarization_matrix`,
     using standard coordinate systems.
     """

--- a/katsdpimager/katsdpimager/test/test_predict.py
+++ b/katsdpimager/katsdpimager/test/test_predict.py
@@ -1,7 +1,5 @@
 """Tests for :mod:`katsdpimager.predict`"""
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import katpoint
 import katsdpsigproc.accel as accel
@@ -12,7 +10,7 @@ from .. import predict, parameters, polarization, sky_model
 from .utils import RandomState
 
 
-class TestPredict(object):
+class TestPredict:
     """Tests for :class:`.Predict`"""
     def _test_random(self, context, queue, n_vis):
         # Deliberately use a strange subset of polarizations, to test that

--- a/katsdpimager/katsdpimager/test/test_preprocess.py
+++ b/katsdpimager/katsdpimager/test/test_preprocess.py
@@ -1,24 +1,24 @@
 """Tests for :py:mod:`katsdpimager.preprocess`."""
 
-from __future__ import division, print_function, absolute_import
-import astropy.units as units
-import numpy as np
 import tempfile
 import logging
 import os
 from contextlib import closing
+
+import astropy.units as units
+import numpy as np
 from nose.tools import assert_equal, assert_true, assert_false
+
 import katsdpimager.parameters as parameters
 import katsdpimager.polarization as polarization
 import katsdpimager.preprocess as preprocess
-from six.moves import range
 
 
 def _empty_recarray(dtype):
     return np.rec.array(None, dtype=dtype, shape=(0,))
 
 
-class BaseTestVisibilityCollector(object):
+class BaseTestVisibilityCollector:
     def setup(self):
         self.image_parameters = []
         self.grid_parameters = []
@@ -158,7 +158,7 @@ class TestVisibilityCollectorMem(BaseTestVisibilityCollector):
 
 class TestVisibilityCollectorHDF5(BaseTestVisibilityCollector):
     def setup(self):
-        super(TestVisibilityCollectorHDF5, self).setup()
+        super().setup()
         self._tmpfiles = []
 
     def factory(self, *args, **kwargs):

--- a/katsdpimager/katsdpimager/test/test_sky_model.py
+++ b/katsdpimager/katsdpimager/test/test_sky_model.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import tempfile
+from unittest import mock
 
 from nose.tools import assert_equal, assert_raises
-import mock
 import fakeredis
 from astropy import units
 import numpy as np
@@ -18,7 +18,7 @@ _TRG_B = 'B, radec, 8:00:00.00, 60:00:00, (200.0 12000.0 2.0 0.0 0.0)'
 _TRG_C = 'C, radec, 21:00:00.00, -60:00:00, (800.0 43200.0 1 0 0 0 0 0  1 0.8 -0.7 0.6)'
 
 
-class TestKatpointSkyModel(object):
+class TestKatpointSkyModel:
     def setUp(self):
         self.catalogue = katpoint.Catalogue([_TRG_A, _TRG_B, _TRG_C])
         self.sky_model = KatpointSkyModel(self.catalogue)
@@ -58,7 +58,7 @@ def _put_target(view, idx, description, targets):
     view['target{}_clean_components'.format(idx)] = d
 
 
-class TestCatalogueFromTelstate(object):
+class TestCatalogueFromTelstate:
     def setUp(self):
         self.cbid = '1234567890'
         self.continuum = 'continuum'
@@ -91,7 +91,7 @@ class TestCatalogueFromTelstate(object):
         assert_equal(len(catalogue), 0)
 
 
-class TestOpenSkyModel(object):
+class TestOpenSkyModel:
     def test_bad_format(self):
         with assert_raises(ValueError):
             open_sky_model('file:///does_not_exist?format=sir_not_appearing_in_this_codebase')

--- a/katsdpimager/katsdpimager/test/test_weight.py
+++ b/katsdpimager/katsdpimager/test/test_weight.py
@@ -1,13 +1,12 @@
 """Tests for :mod:`katsdpimager.weight`."""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 from katsdpsigproc.test.test_accel import device_test
+
 from katsdpimager import weight
-from six.moves import range
 
 
-class TestGridWeights(object):
+class TestGridWeights:
     def setup(self):
         self.grid_shape = (4, 100, 200)
         self.uv = np.array([
@@ -57,7 +56,7 @@ class TestGridWeights(object):
         np.testing.assert_equal(expected, actual)
 
 
-class TestDensityWeights(object):
+class TestDensityWeights:
     def setup(self):
         rs = np.random.RandomState(1)
         self.grid_shape = (4, 50, 107)
@@ -93,7 +92,7 @@ class TestDensityWeights(object):
         np.testing.assert_allclose(self.normalized_rms, normalized_rms, 1e-6)
 
 
-class TestMeanWeight(object):
+class TestMeanWeight:
     def setup(self):
         rs = np.random.RandomState(1)
         self.grid_shape = (4, 50, 107)

--- a/katsdpimager/katsdpimager/test/utils.py
+++ b/katsdpimager/katsdpimager/test/utils.py
@@ -1,13 +1,12 @@
 """Utilities for test code"""
 
-from __future__ import print_function, division, absolute_import
 import numpy as np
 
 
 class RandomState(np.random.RandomState):
     """Extension of :class:`random.RandomState` with extra distributions"""
     def __init__(self, *args, **kwargs):
-        super(RandomState, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def complex_normal(self, loc=0.0j, scale=1.0, size=None):
         """Circularly symmetric Gaussian in the Argand plane"""

--- a/katsdpimager/katsdpimager/types.py
+++ b/katsdpimager/katsdpimager/types.py
@@ -1,6 +1,5 @@
 """Utilities for converting type names between numpy and C"""
 
-from __future__ import division, print_function, absolute_import
 import numpy as np
 
 

--- a/katsdpimager/katsdpimager/weight.py
+++ b/katsdpimager/katsdpimager/weight.py
@@ -45,11 +45,9 @@ different beam shapes for the different polarizations.
 .. include:: macros.rst
 """
 
-from __future__ import division, print_function, absolute_import
 import pkg_resources
 import numpy as np
 from katsdpsigproc import accel, fill
-from six.moves import range
 
 
 NATURAL = 0
@@ -57,7 +55,7 @@ UNIFORM = 1
 ROBUST = 2
 
 
-class GridWeightsTemplate(object):
+class GridWeightsTemplate:
     """Template for accumulating weights onto a grid.
 
     Parameters
@@ -123,7 +121,7 @@ class GridWeights(accel.Operation):
         does not match `template`.
     """
     def __init__(self, template, command_queue, grid_shape, max_vis, allocator=None):
-        super(GridWeights, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self.template = template
         if grid_shape[0] != self.template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
@@ -181,7 +179,7 @@ class GridWeights(accel.Operation):
         }
 
 
-class DensityWeightsTemplate(object):
+class DensityWeightsTemplate:
     """Template for converting cell sum of statistical weights to density weights.
 
     Parameters
@@ -240,7 +238,7 @@ class DensityWeights(accel.Operation):
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, grid_shape, allocator=None):
-        super(DensityWeights, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self.template = template
         if grid_shape[0] != self.template.num_polarizations:
             raise ValueError('Mismatch in number of polarizations')
@@ -288,7 +286,7 @@ class DensityWeights(accel.Operation):
         }
 
 
-class MeanWeightTemplate(object):
+class MeanWeightTemplate:
     """Template for computing the "mean weight", as defined by equation 3.17 in
     [Bri95]_. The input is the gridded statistical weights. The kernel outputs the
     sum of squared cell weights and the sum of weights, and the Python code
@@ -338,7 +336,7 @@ class MeanWeight(accel.Operation):
         Allocator used to allocate unbound slots
     """
     def __init__(self, template, command_queue, grid_shape, allocator=None):
-        super(MeanWeight, self).__init__(command_queue, allocator)
+        super().__init__(command_queue, allocator)
         self.template = template
         self.slots['grid'] = accel.IOSlot(
             (grid_shape[0],
@@ -372,7 +370,7 @@ class MeanWeight(accel.Operation):
         return self._sums_host[1] / self._sums_host[0]
 
 
-class WeightsTemplate(object):
+class WeightsTemplate:
     """Compound template for computing imaging weights.
 
     Parameters
@@ -493,7 +491,7 @@ class Weights(accel.OperationSequence):
         else:
             self._density_weights = None
 
-        super(Weights, self).__init__(command_queue, operations, compounds, allocator=allocator)
+        super().__init__(command_queue, operations, compounds, allocator=allocator)
 
     def _run(self):
         raise NotImplementedError('Weights should not be used as a callable')
@@ -531,7 +529,7 @@ class Weights(accel.OperationSequence):
         return normalized_rms
 
 
-class WeightsHost(object):
+class WeightsHost:
     """Equivalent to :class:`Weights` that runs on the host.
 
     Parameters

--- a/katsdpimager/requirements.txt
+++ b/katsdpimager/requirements.txt
@@ -1,60 +1,47 @@
 ansicolors
-appdirs
-argparse
-astropy==1.3
-botocore
-chardet
-certifi
-dask
-decorator
-defusedxml
-docutils
-enum34
-fakeredis
-funcsigs
-future
-futures
-h5py
-idna
-ipaddress
-jmespath
-katversion
-linecache2
-llvmlite
+appdirs                   # via katsdpsigproc
+astropy==3.1.2
+botocore                  # for S3 authentication in katdal
+chardet                   # via requests
+certifi                   # via requests
+dask                      # via katdal
+decorator                 # via pycuda, katsdpsigproc
+defusedxml                # via katdal
+docutils                  # via botocore
+future                    # via katdal, katpoint
+futures                   # via katsdpsigsproc
+h5py                      # via katdal
+idna                      # via requests
+ipaddress                 # via katsdptelstate
+jmespath                  # via botocore
+llvmlite                  # via numba
 Mako
-MarkupSafe
-mock
-msgpack
-netifaces
-nose
+MarkupSafe                # via Mako
+msgpack                   # via katsdptelstate
+netifaces                 # via katsdptelstate
 numba
 numpy
-pandas
-pbr
+pandas                    # via katsdpsigproc
 pkgconfig==1.1.0
 progress==1.2
-py
-pybind11==2.2.3
+py                        # via pytest
+pybind11==2.2.4
 pycuda
-pyephem
-pytest
+pyephem                   # via katpoint
+pytest                    # via pycuda
 python-casacore
-python-dateutil
-python-lzf
-pytools
-pytz
-rdbtools
-redis
-requests
+python-dateutil           # via pandas, botocore
+python-lzf                # via katsdptelstate
+pytools                   # via pycuda
+pytz                      # via pandas
+rdbtools                  # via katsdptelstate
+redis                     # via katsdptelstate
+requests                  # via katdal
 scikit-cuda
-scipy
-singledispatch
-six
-toolz
-traceback2
-trollius
-unittest2
-urllib3
+scipy                     # via katdal (its fallback interpolation behaves differently)
+six                       # via pytools, python-dateutil
+toolz                     # via dask[array]
+urllib3                   # via requests
 
 git+ssh://git@github.com/ska-sa/katdal#egg=katdal
 git+ssh://git@github.com/ska-sa/katpoint#egg=katpoint

--- a/katsdpimager/scripts/fitsdiffwcs.py
+++ b/katsdpimager/scripts/fitsdiffwcs.py
@@ -11,15 +11,15 @@ corresponding pixel in the second file, interpolating as necessary, or
 reporting NaN if it falls outside the footprint.
 """
 
-from __future__ import division, print_function, absolute_import
 import argparse
+
 import numpy as np
 import scipy.interpolate
 import astropy.io.fits as fits
 import astropy.wcs as wcs
 
 
-class FitsFile(object):
+class FitsFile:
     def __init__(self, filename):
         self.hdulist = fits.open(filename)
         self.xform = wcs.WCS(self.hdulist[0].header, self.hdulist)

--- a/katsdpimager/scripts/imager.py
+++ b/katsdpimager/scripts/imager.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
-from __future__ import division, print_function, absolute_import
 import sys
 import argparse
+import logging
+import os
+import atexit
+from contextlib import closing, contextmanager
+import tempfile
+
 import astropy.units as units
 import numpy as np
-import logging
 import colors
-import tempfile
-import atexit
-import os
 import katsdpsigproc.accel as accel
+
 from katsdpimager import \
     loader, parameters, polarization, preprocess, io, clean, weight, sky_model, \
     imaging, progress, beam, numba
-from contextlib import closing, contextmanager
-from six.moves import range
 
 
 logger = logging.getLogger()
@@ -190,7 +190,7 @@ def data_iter(dataset, args, start_channel, stop_channel):
                 return
 
 
-class DummyCommandQueue(object):
+class DummyCommandQueue:
     """Stub equivalent to CUDA/OpenCL CommandQueue objects, that just provides
     an empty :meth:`finish` method."""
     def finish(self):
@@ -314,10 +314,10 @@ class ColorFormatter(logging.Formatter):
     }
 
     def __init__(self, *args, **kwargs):
-        super(ColorFormatter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def format(self, record):
-        msg = super(ColorFormatter, self).format(record)
+        msg = super().format(record)
         if record.levelno in self.COLORS:
             msg = self.COLORS[record.levelno](msg)
         return msg
@@ -354,7 +354,7 @@ def dummy_context():
     yield
 
 
-class ChannelParameters(object):
+class ChannelParameters:
     """Collects imaging parameters for a single channel.
 
     Parameters

--- a/katsdpimager/setup.py
+++ b/katsdpimager/setup.py
@@ -8,10 +8,10 @@ try:
 except ImportError:
     eigen3 = {'include_dirs': set()}
 
-tests_require = ['nose', 'mock', 'scipy', 'fakeredis']
+tests_require = ['nose', 'scipy', 'fakeredis']
 
 
-class get_include(object):
+class get_include:
     """Helper class to defer importing a module until build time for fetching the include directory.
     """
     def __init__(self, module, *args, **kwargs):
@@ -48,10 +48,11 @@ setup(
     scripts=["scripts/imager.py"],
     ext_package='katsdpimager',
     ext_modules=extensions,
+    python_requires='>=3.5',       # Somewhat arbitrary choice; only tested with 3.6+
     setup_requires=['pkgconfig', 'pybind11>=2.2.0'],
     install_requires=[
         'numpy>=1.10.0', 'katsdpsigproc', 'katpoint', 'astropy>=1.3', 'progress',
-        'pycuda', 'scikit-cuda', 'h5py', 'ansicolors', 'six'
+        'pycuda', 'scikit-cuda', 'h5py', 'ansicolors'
     ],
     tests_require=tests_require,
     extras_require={

--- a/katsdpimager/test-requirements.txt
+++ b/katsdpimager/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+fakeredis
 funcsigs
 mock
 nose

--- a/katsdpimager/tests/imager_bench.py
+++ b/katsdpimager/tests/imager_bench.py
@@ -2,17 +2,17 @@
 
 """Benchmark suite for various steps in imaging"""
 
-from __future__ import division, print_function, absolute_import
 import argparse
+import timeit
+import json
+
 import katpoint
 import pkg_resources
 import numpy as np
-import timeit
-import json
 from astropy import units
-from katsdpimager import grid, preprocess, parameters, polarization, fft
 from katsdpsigproc import accel
-from six.moves import range
+
+from katsdpimager import grid, preprocess, parameters, polarization, fft
 
 
 def load_antennas():

--- a/katsdpimager/tests/images_report.py
+++ b/katsdpimager/tests/images_report.py
@@ -4,7 +4,6 @@
 Creates an HTML page showing the images written by the Jenkins script.
 """
 
-from __future__ import division, print_function, absolute_import
 import argparse
 import os
 import os.path
@@ -16,8 +15,6 @@ import timeit
 import io
 import glob
 from contextlib import closing
-
-from six.moves import range
 
 from mako.template import Template
 import matplotlib
@@ -32,7 +29,7 @@ MODE_DIRTY = 'Dirty'
 MODES = [MODE_CLEAN, MODE_DIRTY]
 
 
-class BuildInfo(object):
+class BuildInfo:
     """Runs a command and stores the output and exit code. The output is also
     echoed to stdout.
     """
@@ -62,7 +59,7 @@ class BuildInfo(object):
         logging.info("Elapsed time %.3f", self.elapsed)
 
 
-class Image(object):
+class Image:
     def __init__(self, name, filebase,
                  clean_fits_pattern, dirty_fits_pattern, cmd_patterns,
                  clean_globs=[]):


### PR DESCRIPTION
Removes all use of
- six
- explicit inheritance from object
- old forms of super (replace by zero-argument super)
- `from __future__`

Import blocks have also been shuffled a bit to be more PEP 8 compliant,
a few packages (astropy, pybind) have been updated to newer versions,
and requirements.txt has been trimmed and the dependency chains
documented.