### PR TITLE
Update information about who owns katsdppipelines packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 @Library('katsdpjenkins') _
-def maintainer = 'bmerry@ska.ac.za sperkins@ska.ac.za kmcalpine@ska.ac.za'
+def maintainer = 'bmerry@ska.ac.za tmauch@ska.ac.za kmcalpine@ska.ac.za'
 if (!katsdp.isTegra()) {
     katsdp.setDependencies([
         'ska-sa/katsdpdockerbase/master',

--- a/katsdpcal/Dockerfile
+++ b/katsdpcal/Dockerfile
@@ -1,5 +1,4 @@
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build as build
-MAINTAINER Tom Mauch "tmauch@ska.ac.za"
 
 # Enable Python 2 venv
 ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"
@@ -20,7 +19,6 @@ WORKDIR /tmp
 #######################################################################
 
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-runtime
-MAINTAINER Tom Mauch "tmauch@ska.ac.za"
 
 COPY --from=build --chown=kat:kat /home/kat/ve /home/kat/ve
 ENV PATH="$PATH_PYTHON2" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON2"

--- a/katsdpcontim/Dockerfile
+++ b/katsdpcontim/Dockerfile
@@ -1,5 +1,4 @@
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-build:latest as build
-MAINTAINER sperkins@ska.ac.za
 
 # Switch to root for package install
 USER root
@@ -124,7 +123,6 @@ RUN pip install $KATHOME/src/katacomb
 #######################################################################
 
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-runtime:latest
-MAINTAINER sperkins@ska.ac.za
 
 # Switch to root for package install
 USER root


### PR DESCRIPTION
The MAINTAINER lines were removed from the Dockerfile since they're
deprecated and not terribly useful if they aren't kept up to date (Git
history is a much better indicator of who is maintaining a package).

Added @mauch and removed @sjperkins from the Jenkins spam list.