### PR TITLE
Add aiomonitor to cal

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -1632,7 +1632,7 @@ class CalDeviceServer(aiokatcp.DeviceServer):
     def __exit__(self, exc_type, exc_value, traceback):
         # When used as a context manager, a server will ensure its child
         # processes are killed.
-        for task in [self.report_writer, self.pipeline]:
+        for task in self.children:
             if task.is_alive() and hasattr(task, 'terminate'):
                 task.terminate()
 

--- a/katsdpcal/requirements.txt
+++ b/katsdpcal/requirements.txt
@@ -1,5 +1,7 @@
 appdirs                 # for katsdpsigproc
+aioconsole
 aiokatcp
+aiomonitor
 async_timeout
 attrs
 bokeh
@@ -46,6 +48,7 @@ scipy
 sortedcontainers==1.5.9
 spead2
 tblib==1.3.2            # for distributed
+terminaltables          # for aiomonitor
 toolz                   # for dask
 tornado                 # for distributed, bokeh
 urllib3                 # for requests

--- a/katsdpcal/setup.py
+++ b/katsdpcal/setup.py
@@ -35,7 +35,7 @@ setup(
         "dask[array,distributed]>=1.1.0", "distributed>=1.12.0", "bokeh",
         "attrs", "sortedcontainers",
         "aiokatcp", "async_timeout",
-        "katpoint", "katdal", "katsdptelstate", "katsdpservices[argparse]",
+        "katpoint", "katdal", "katsdptelstate", "katsdpservices[argparse,aiomonitor]",
         "katsdpsigproc", "spead2>=1.8.0", "docutils", "matplotlib>=2",
         "jsonschema"
     ],


### PR DESCRIPTION
The main script got shuffled around somewhat to accommodate the annoying
requirement that aiomonitor has to be started before the event loop is
run. While that would have been simple to do, it would not have given
access to all the interesting local variables. So instead, most of the
script code is now run before starting the event loop (in `main`), and
only the minimum code necessary is run inside the event loop (in `run`).

Also fixed in bug in the `__exit__` for CalDeviceSender, where the
sender process was not killed.