### PR TITLE
Fix mask selecting all baselines to an antenna

### DIFF
--- a/katsdpcal/katsdpcal/calprocs.py
+++ b/katsdpcal/katsdpcal/calprocs.py
@@ -341,9 +341,9 @@ def best_refant(data, corrprod_lookup, chans):
 
     Parameters:
     -----------
-    data : :class:`np.ndarray`, array of complex, shape(n_chans, n_pols, n_bls)
+    data : :class:`np.ndarray`, complex, shape(n_chans, n_pols, n_bls)
         visibility data
-    corrprod_lookup : :class:`np.ndarray`, array of int,  shape (2, n_bls)
+    corrprod_lookup : :class:`np.ndarray`, int,  shape (2, n_bls)
         antenna pairs for selected baselines
     chans : :class:`np.ndarray`
         channel frequencies in Hz


### PR DESCRIPTION
This is to address jira ticket https://skaafrica.atlassian.net/browse/SR-1542.
The previous method of constructing this mask would intermittently produce a mask
with a shape which was inconsistent with a number of baselines. This is intended to
produce this mask in a more robust manner.