### PR TITLE
Fix cal for newer numpy

### DIFF
--- a/katsdpcal/katsdpcal/calprocs_dask.py
+++ b/katsdpcal/katsdpcal/calprocs_dask.py
@@ -57,7 +57,7 @@ def stefcal(rawvis, num_ants, corrprod_lookup, weights=None, ref_ant=0,
     # Determine the output dtype, since the gufunc has two signatures
     if (np.can_cast(rawvis.dtype, np.complex64)
             and np.can_cast(weights.dtype, np.float32)
-            and np.can_cast(init_gain, np.complex64)):
+            and np.can_cast(init_gain.dtype, np.complex64)):
         dtype = np.complex64
     else:
         dtype = np.complex128


### PR DESCRIPTION
While running against numpy master (to track down a related issue) I ran
into an error when trying to use np.can_cast on a dask array. Pass it
the dtype instead.