### PR TITLE
Modernise use of telstate

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -695,8 +695,7 @@ class Accumulator:
             with concurrent.futures.ThreadPoolExecutor(1) as executor:
                 server_id = self.owner.parameters['server_id']
                 n_servers = self.owner.parameters['servers']
-                self.telstate_cb_cal.add('last_dump_index{}'.format(server_id),
-                                         self._last_idx, immutable=True)
+                self.telstate_cb_cal['last_dump_index{}'.format(server_id)] = self._last_idx
                 for i in range(n_servers):
                     if i != server_id:
                         key = 'last_dump_index{}'.format(i)
@@ -1251,19 +1250,19 @@ class Transmitter:
         # The flags stream is mostly the same shape/layout as the L0 stream,
         # with the exception of channelisation.
         for key in ['bandwidth', 'int_time', 'sync_time', 'excise', 'n_bls', 'bls_ordering']:
-            self.telstate_flags.add(key, l0_attr[key], immutable=True)
+            self.telstate_flags[key] = l0_attr[key]
         old_spw = SpectralWindow(centre_freq=l0_attr['center_freq'],
                                  bandwidth=l0_attr['bandwidth'],
                                  num_chans=l0_attr['n_chans'],
                                  channel_width=None,    # Computed from bandwidth
                                  sideband=1)
         new_spw = old_spw.rechannelise(l0_attr['n_chans'] // flags_stream.continuum_factor)
-        self.telstate_flags.add('center_freq', new_spw.centre_freq, immutable=True)
-        self.telstate_flags.add('n_chans', new_spw.num_chans, immutable=True)
-        self.telstate_flags.add('n_chans_per_substream', out_chans, immutable=True)
-        self.telstate_flags.add('src_streams', [flags_stream.src_stream], immutable=True)
-        self.telstate_flags.add('stream_type', 'sdp.flags', immutable=True)
-        self.telstate_flags.add('calibrations_applied', [cal_name], immutable=True)
+        self.telstate_flags['center_freq'] = new_spw.centre_freq
+        self.telstate_flags['n_chans'] = new_spw.num_chans
+        self.telstate_flags['n_chans_per_substream'] = out_chans
+        self.telstate_flags['src_streams'] = [flags_stream.src_stream]
+        self.telstate_flags['stream_type'] = 'sdp.flags'
+        self.telstate_flags['calibrations_applied'] = [cal_name]
 
     def prepare(self):
         """Do further setup in the child process."""
@@ -1278,7 +1277,7 @@ class Transmitter:
         self._tx.send_heap(self._ig.get_start())
         self._ig['capture_block_id'].value = cbid
         telstate_cb_flags = make_telstate_cb(self.telstate_flags, cbid)
-        telstate_cb_flags.add('first_timestamp', first_timestamp, immutable=True)
+        telstate_cb_flags['first_timestamp'] = first_timestamp
 
     def end_capture_block(self):
         """Send an end-of-stream heap that includes capture block ID"""

--- a/katsdpcal/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/katsdpcal/pipelineprocs.py
@@ -339,7 +339,7 @@ def parameters_to_telstate(parameters, telstate_cal, l0_name):
             else:
                 key = 'param_' + parameter.name
             value = parameter.converter.to_telstate(parameters[parameter.name], parameters)
-            telstate_cal.add(key, value, immutable=True)
+            telstate_cal[key] = value
     for parameter in COMPUTED_PARAMETERS:
         # Only put them in if explicitly set to True
         if parameter.telstate:
@@ -348,16 +348,16 @@ def parameters_to_telstate(parameters, telstate_cal, l0_name):
             else:
                 key = parameter.name
             value = parameter.converter.to_telstate(parameters[parameter.name], parameters)
-            telstate_cal.add(key, value, immutable=True)
+            telstate_cal[key] = value
 
-    telstate_cal.add('stream_type', 'sdp.cal', immutable=True)
+    telstate_cal['stream_type'] = 'sdp.cal'
     # Transfer some keys from L0 stream to cal "stream", to help consumers compute
     # frequencies.
     telstate_l0 = telstate_cal.root().view(l0_name)
     for key in ['bandwidth', 'n_chans', 'center_freq']:
-        telstate_cal.add(key, telstate_l0[key], immutable=True)
+        telstate_cal[key] = telstate_l0[key]
     # Add the L0 stream name too, so that any other information can be found there.
-    telstate_cal.add('src_streams', [l0_name], immutable=True)
+    telstate_cal['src_streams'] = [l0_name]
 
 
 def get_baseline_mask(bls_lookup, ants, limits):

--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -219,7 +219,7 @@ def shared_solve(telstate, parameters, solution_store, bchan, echan,
     # sequence number. If `name` is not given, the metadata contains the actual
     # values.
     def add_info(info):
-        telstate.add(shared_key, info, immutable=True)
+        telstate[shared_key] = info
         logger.debug('Added shared key %s', shared_key)
 
     if '_seq' in kwargs:
@@ -434,7 +434,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             model_params, model_file = pp.get_model(target_name, lsm_dir)
             if model_params is not None:
                 s.add_model(model_params)
-                ts.add(model_key, model_params, immutable=True)
+                ts[model_key] = model_params
                 logger.info('   Model file: {0}'.format(model_file))
         else:
             s.add_model(model_params)
@@ -455,7 +455,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 parameters['refant_index'] = best_refant_index
                 parameters['refant'] = parameters['antennas'][best_refant_index]
                 logger.info('Reference antenna set to %s', parameters['refant'].name)
-                ts.add('refant', parameters['refant'].description, immutable=True)
+                ts['refant'] = parameters['refant'].description
                 s.refant = best_refant_index
 
         # run_t0 = time.time()

--- a/katsdpcal/katsdpcal/simulator.py
+++ b/katsdpcal/katsdpcal/simulator.py
@@ -185,7 +185,7 @@ class SimData:
         # add parameters to telescope state
         for key, value in sorted(notime_dict.items()):
             logger.info('Setting %s = %s', key, value)
-            telstate.add(key, value, immutable=True)
+            telstate[key] = value
 
         for key, value in sorted(time_dict.items()):
             logger.info('Setting %s', key)
@@ -256,7 +256,8 @@ class SimData:
 
     def setup_capture_block(self, telstate, first_timestamp):
         """Set per-capture-block keys in telstate."""
-        telstate.add(self.cbid + '_sdp_l0_first_timestamp', first_timestamp, immutable=True)
+        key = telstate.join(self.cbid, 'sdp_l0', 'first_timestamp')
+        telstate[key] = first_timestamp
 
     def transmit_item(self, tx, ig, dump_index, timestamp, correlator_data, flags, weights):
         """
@@ -533,7 +534,7 @@ class SimDataMS(SimData):
                       'sb_id_code' : 'None',
                       'proposal_id' : 'None',
                       'observer' : 'unknown'}
-        telstate_cb.add('obs_params', obs_params, immutable=True)
+        telstate_cb['obs_params'] = obs_params
 
         time_ind = 0
         # send data scan by scan
@@ -723,7 +724,7 @@ class SimDataKatdal(SimData):
         telstate_cb = telstate.view(self.cbid)
 
         # include obs params in telstate
-        telstate_cb.add('obs_params', self.file.obs_params, immutable=True)
+        telstate_cb['obs_params'] = self.file.obs_params
         for scan_ind, scan_state, target in self.file.scans():
             # update telescope state with scan information
             #   subtract random offset to time, <= 0.1 seconds, to simulate

--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -232,28 +232,28 @@ class TestCalDeviceServer(asynctest.TestCase):
             bls_ordering.append((a + 'v', b + 'v'))
             bls_ordering.append((a + 'h', b + 'v'))
             bls_ordering.append((a + 'v', b + 'h'))
-        telstate.add('subarray_product_id', 'c856M4k', immutable=True)
-        telstate.add('sub_band', 'l', immutable=True)
+        telstate['subarray_product_id'] = 'c856M4k'
+        telstate['sub_band'] = 'l'
         telstate.add('cbf_target', target, ts=0)
-        telstate_l0.add('int_time', 4.0, immutable=True)
-        telstate_l0.add('bls_ordering', bls_ordering, immutable=True)
-        telstate_l0.add('n_bls', len(bls_ordering), immutable=True)
-        telstate_l0.add('bandwidth', 856000000.0, immutable=True)
-        telstate_l0.add('center_freq', 1284000000.0, immutable=True)
-        telstate_l0.add('n_chans', self.n_channels, immutable=True)
-        telstate_l0.add('n_chans_per_substream', self.n_channels_per_substream, immutable=True)
-        telstate_l0.add('sync_time', 1400000000.0, immutable=True)
-        telstate_l0.add('excise', True, immutable=True)
-        telstate_l0.add('need_weights_power_scale', True, immutable=True)
-        telstate_cb_l0 = telstate.view(telstate.SEPARATOR.join(('cb', 'sdp_l0test')))
-        telstate_cb_l0.add('first_timestamp', 100.0, immutable=True)
+        telstate_l0['int_time'] = 4.0
+        telstate_l0['bls_ordering'] = bls_ordering
+        telstate_l0['n_bls'] = len(bls_ordering)
+        telstate_l0['bandwidth'] = 856000000.0
+        telstate_l0['center_freq'] = 1284000000.0
+        telstate_l0['n_chans'] = self.n_channels
+        telstate_l0['n_chans_per_substream'] = self.n_channels_per_substream
+        telstate_l0['sync_time'] = 1400000000.0
+        telstate_l0['excise'] = True
+        telstate_l0['need_weights_power_scale'] = True
+        telstate_cb_l0 = telstate.view(telstate.join('cb', 'sdp_l0test'))
+        telstate_cb_l0['first_timestamp'] = 100.0
         telstate_cb = telstate.view('cb')
         telstate_cb.add('obs_activity', 'track', ts=0)
         obs_params = {'description' : 'test observation',
                       'proposal_id' : '123_03',
                       'sb_id_code' : '123_0005',
                       'observer' : 'Kim'}
-        telstate_cb.add('obs_params', obs_params, immutable=True)
+        telstate_cb['obs_params'] = obs_params
         for antenna in self.antennas:
             # The position is irrelevant for now, so just give all the
             # antennas the same position.

--- a/katsdpcal/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/katsdpcal/test/test_pipelineprocs.py
@@ -94,12 +94,12 @@ class TestFinaliseParameters(unittest.TestCase):
         self.telstate = katsdptelstate.TelescopeState()
         self.telstate.clear()
         self.telstate_l0 = self.telstate.view('sdp_l0test')
-        self.telstate_l0.add('n_chans', 4096, immutable=True)
-        self.telstate_l0.add('bandwidth', 856000000.0, immutable=True)
-        self.telstate_l0.add('center_freq', 1284000000.0, immutable=True)
-        self.telstate_l0.add('bls_ordering', bls_ordering, immutable=True)
+        self.telstate_l0['n_chans'] = 4096
+        self.telstate_l0['bandwidth'] = 856000000.0
+        self.telstate_l0['center_freq'] = 1284000000.0
+        self.telstate_l0['bls_ordering'] = bls_ordering
         for antenna in self.antennas:
-            self.telstate.add(antenna.name + '_observer', antenna.description, immutable=True)
+            self.telstate[self.telstate.join(antenna.name, 'observer')] = antenna.description
 
     def test_normal(self):
         parameters = pipelineprocs.finalise_parameters(

--- a/katsdpcontim/katacomb/katacomb/aips_export.py
+++ b/katsdpcontim/katacomb/katacomb/aips_export.py
@@ -249,7 +249,7 @@ def export_clean_components(clean_files, target_indices, kat_adapter, telstate):
 
                     # Store them in telstate
                     key = telstate.join(target, "clean_components")
-                    telstate.add(key, data, immutable=True)
+                    telstate[key] = data
 
         except Exception as e:
             log.warn("Export of clean components from '%s' failed.\n%s",

--- a/katsdpimager/katsdpimager/sky_model.py
+++ b/katsdpimager/katsdpimager/sky_model.py
@@ -107,7 +107,7 @@ def catalogue_from_telstate(telstate, capture_block_id, continuum, target):
     # if we are run under Python 3.
     from katdal.sensordata import TelstateToStr
 
-    prefix = telstate.SEPARATOR.join([capture_block_id, continuum])
+    prefix = telstate.join(capture_block_id, continuum)
     view = TelstateToStr(telstate.view(prefix))
     for i in itertools.count():
         key = 'target{}_clean_components'.format(i)
@@ -118,8 +118,8 @@ def catalogue_from_telstate(telstate, capture_block_id, continuum, target):
             if katpoint.Target(data['description']) == target:
                 return katpoint.Catalogue(data['components'])
         except KeyError:
-            logger.warning('Failed to access %s%s%s from telescope state',
-                           prefix, telstate.SEPARATOR, key, exc_info=True)
+            logger.warning('Failed to access %s from telescope state',
+                           telstate.join(prefix, key), exc_info=True)
     logger.warning('Sky model for target %s not found', target.name)
     return katpoint.Catalogue()
 


### PR DESCRIPTION
- Remove all references to telstate.SEPARATOR, and use telstate.join
  instead.
- Replace use of telstate.add(..., immutable=True) with __setitem__