### PR TITLE
Interpolate across NaNs in B solutions

### DIFF
--- a/katsdpcal/katsdpcal/calprocs.py
+++ b/katsdpcal/katsdpcal/calprocs.py
@@ -13,6 +13,7 @@ import numba
 
 import katpoint
 
+from katdal.applycal import complex_interp
 
 logger = logging.getLogger(__name__)
 
@@ -581,6 +582,34 @@ def normalise_complex(x):
     norm_factor = centre_rotation / average_amplitude
 
     return norm_factor
+
+
+def interpolate_bandpass(x):
+    """
+    Interpolate over NaNs in the channel axis of a bandpass
+
+    Parameters
+    ----------
+    x : :class:`np.ndarray`, complex, shape(nchans, npols, nants)
+        bandpass to interpolate over
+
+    Returns
+    -------
+    x_interp : :class`np.ndarray`
+         interpolated bandpass
+    """
+    nchans, npols, nants = x.shape
+    x_interp = np.empty_like(x)
+    for p in range(npols):
+        for a in range(nants):
+            valid = np.isfinite(x[:, p, a])
+            if np.any(valid):
+                x_interp[:, p, a] = complex_interp(np.arange(nchans),
+                                                   np.arange(nchans)[valid],
+                                                   x[:, p, a][valid])
+            else:
+                x_interp[:, p, a] = np.nan
+    return x_interp
 
 
 def asbool(arr):

--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -6,6 +6,7 @@ import katpoint
 from numbers import Integral
 
 import numpy as np
+import katsdptelstate
 
 from collections import defaultdict
 from katdal.sensordata import TelstateSensorData, SensorCache
@@ -17,6 +18,7 @@ from . import solutions
 from . import pipelineprocs as pp
 from .scan import Scan
 from . import lsm_dir
+from .calprocs import interpolate_bandpass
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +316,64 @@ def shared_solve(telstate, parameters, solution_store, bchan, echan,
         return soln
 
 
+def shared_B_interp_nans(telstate, parameters, b_soln, st, et):
+    """
+    Interpolate over NaNs in the channel axis of the bandpass
+
+    If there are multiple cal nodes, retrieve all parts of the
+    bandpass from telstate prior to interpolation.
+
+    Parameters:
+    -----------
+    telstate : :class:`katsdptelstate.TelescopeState`
+        Telescope state in which the solution is stored
+    parameters : dict
+        Pipeline parameters
+    b_soln : :class:`~.CalSolution`
+        bandpass solution for this cal node
+    st : float
+        start time for retrieving solutions from telstate
+    et : float
+        end time for retrieving solutions from telstate
+
+    Returns:
+    --------
+    :class:`~.CalSolution`
+        interpolated solution for this cal node
+    """
+    # if there are multiple cal nodes
+    # retrieve parts of the bandpass computed by other cal nodes
+    if parameters['servers'] > 1:
+        parts = []
+        for n in range(parameters['servers']):
+            if n == parameters['server_id']:
+                parts.append(b_soln.values)
+
+            else:
+                key = 'product_B{0}'.format(n)
+                try:
+                    telstate.wait_key(key, lambda value, ts: ts > st, 30)
+                    valid_part = telstate.get_range('product_B{0}'.format(n), st, et)
+                    parts.append(valid_part[0][0])
+
+                except (KeyError, katsdptelstate.TimeoutError):
+                    logger.info("Unable to retrieve %s from telstate,"
+                                " filling with NaNs while interpolating", key)
+                    parts.append(np.full_like(b_soln.values, np.nan))
+
+        b_values = np.concatenate(parts)
+    else:
+        # else use the values computed by this (the only) node
+        b_values = b_soln.values
+
+    # interpolate over NaNs along the channel axis
+    b_interp = interpolate_bandpass(b_values)
+
+    # select channels processed by this cal node
+    b_interp = b_interp[parameters['channel_slice']]
+    return solutions.CalSolution('B', b_interp, b_soln.time)
+
+
 def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
     """
     Pipeline calibration
@@ -482,7 +542,14 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                                          parameters['g_bchan'], parameters['g_echan'],
                                          s.b_norm, b_soln)
             b_soln.values *= b_norm_factor
-            save_solution(ts, parameters['product_names']['B'], solution_stores['B'], b_soln)
+            # flagged bandpasses (with NaNs) are stored in telstate
+            ts.add(parameters['product_names']['B'], b_soln.values, ts=b_soln.time)
+            b_soln_nonans = shared_B_interp_nans(ts, parameters, b_soln,
+                                                 s.timestamps[0], s.timestamps[-1])
+
+            # interpolated bandpasses (without NaNs) are stored in solution store
+            # so they can be applied to target/calibrator data without propagating NaNs
+            solution_stores['B'].add(b_soln_nonans)
 
             # ---------------------------------------
             # G solution
@@ -609,7 +676,14 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                                          parameters['g_bchan'], parameters['g_echan'],
                                          s.b_norm, b_soln)
             b_soln.values *= b_norm_factor
-            save_solution(ts, parameters['product_names']['B'], solution_stores['B'], b_soln)
+            # flagged solutions (with NaNs) are stored in telstate
+            ts.add(parameters['product_names']['B'], b_soln.values, ts=b_soln.time)
+            b_soln_nonans = shared_B_interp_nans(ts, parameters, b_soln,
+                                                 s.timestamps[0], s.timestamps[-1])
+
+            # interpolated solutions (without NaNs) are stored in the solution store
+            # so they can be applied to target/calibrator data without propagating NaNs
+            solution_stores['B'].add(b_soln_nonans)
 
         # GAIN
         if any('gaincal' in k for k in taglist):

--- a/katsdpcal/katsdpcal/scan.py
+++ b/katsdpcal/katsdpcal/scan.py
@@ -11,7 +11,6 @@ from scipy.constants import c as light_speed
 import scipy.interpolate
 
 from katdal.h5datav3 import FLAG_NAMES
-from katdal.applycal import complex_interp
 import katpoint
 
 from . import calprocs, calprocs_dask, inplace
@@ -780,9 +779,8 @@ class Scan:
     # ---------------------------------------------------------------------------------------------
     # interpolation
 
-    def interpolate(self, solns, interp_chan=True):
+    def interpolate(self, solns):
         """Interpolate a solution to the timestamps of the scan.
-           Optionally interpolate across NaNs along the frequency axis
 
         Converts either a :class:`CalSolution` or :class:`CalSolutions` to a
         :class:`CalSolutions`. A :class:`CalSolution` is simply expanded to a
@@ -795,7 +793,7 @@ class Scan:
         if isinstance(solns, CalSolutions):
             return self.linear_interpolate(solns)
         else:
-            return self.inf_interpolate(solns, interp_chan)
+            return self.inf_interpolate(solns)
 
     def linear_interpolate(self, solns):
         values = solns.values
@@ -814,23 +812,10 @@ class Scan:
                 + 1.0j * imag_interp(self.timestamps).astype(np.float32)
             return CalSolutions(solns.soltype, interp_solns, self.timestamps)
 
-    def inf_interpolate(self, soln, interp_chan):
-        """Expand a single solution to span all timestamps of the scan, optionally
-           interpolate across NaNs along the frequency axis"""
+    def inf_interpolate(self, soln):
+        """Expand a single solution to span all timestamps of the scan"""
         values = soln.values
         interp_solns = np.expand_dims(values, axis=0)
-
-        if interp_solns.ndim == 4 and interp_chan:
-            ntimes, nchans, npols, nants = interp_solns.shape
-            interp_chans = np.empty_like(interp_solns)
-            for p in range(npols):
-                for a in range(nants):
-                    valid = np.isfinite(interp_solns[0, :, p, a])
-                    interp_chans[0, :, p, a] = complex_interp(np.arange(nchans),
-                                                              np.arange(nchans)[valid],
-                                                              interp_solns[0, :, p, a][valid])
-            interp_solns = interp_chans
-
         return CalSolutions(soln.soltype, interp_solns, self.timestamps)
 
     # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Applying B solutions with NaNs to the target propagates these NaN's
to the target data which can result in unusual/unexpected flagging
patterns in the target data.

This commit interpolates across NaNs in the frequency axis prior to
applying the solution and thus relies on the target flagger to flag
RFI in the target.