### PR TITLE
Increase timeout for building katsdpcontim image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,8 @@ if (!katsdp.isTegra()) {
     katsdp.standardBuild(subdir: 'katsdpcal', python3: true, python2: false, docker_venv: true)
     katsdp.standardBuild(subdir: 'katsdpcontim',
                          cuda: true,
-                         label: 'cpu-avx2')
+                         label: 'cpu-avx2',
+                         docker_timeout: [time: 90, unit: 'MINUTES'])
 }
 else {
     katsdp.setDependencies(['tegra_ska-sa/katsdpdockerbase/master'])


### PR DESCRIPTION
It's been timing out sometimes when the build server is overloaded.