### PR TITLE
Update and fix the dev container

### DIFF
--- a/katsdpcontim/Dockerfile.dev
+++ b/katsdpcontim/Dockerfile.dev
@@ -12,7 +12,8 @@ ENV PACKAGES \
     vim \
     git \
     cvs \
-    subversion
+    subversion \
+    rsync
 
 # Update, upgrade and install packages
 RUN apt-get update && \
@@ -20,6 +21,12 @@ RUN apt-get update && \
     apt-get install -y $PACKAGES && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install a working parseltongue
+RUN add-apt-repository -y ppa:kettenis-w/parseltongue
+RUN apt-get -y update
+RUN apt-get -y install parseltongue
+
 
 ENV AIPS_BASE_PATH /home/kat/AIPS
 ENV AIPS_DATA_PATH /home/kat/AIPS/DATA
@@ -34,7 +41,7 @@ RUN mkdir -p $AIPS_BASE_PATH
 RUN mkdir -p $AIPS_DATA_PATH
 WORKDIR $AIPS_BASE_PATH
 
-RUN curl ftp://ftp.aoc.nrao.edu/pub/software/aips/31DEC17/install.pl -O
+RUN curl ftp://ftp.aoc.nrao.edu/pub/software/aips/31DEC19/install.pl -O
 
 # Remove root user check:
 RUN sed -i -e '455,461d' install.pl


### PR DESCRIPTION
This provides some minor updates and fixes to the dev dockerfile:

Update AIPS version to 31DEC19
Add parseltongue
Install missing rsync so the AIPS scripts run

@vasaantk since we went through this together can you take a look. Please don't delete the branch because we might want to add more to the container a little further down the line.