### PR TITLE
Add an array reference antenna to the mock dataset

### DIFF
--- a/katsdpcontim/katacomb/katacomb/mock_dataset.py
+++ b/katsdpcontim/katacomb/katacomb/mock_dataset.py
@@ -420,6 +420,11 @@ class MockDataSet(DataSet):
             ant_catdata = CategoricalData([ant], [0, self._ndumps])
             self.sensor['Antennas/%s/antenna' % (ant.name,)] = ant_catdata
 
+        # Extract array reference from first antenna (first 5 fields of description)
+        array_ant_fields = ['array'] + antenna[0].description.split(',')[1:5]
+        array_ant = katpoint.Antenna(','.join(array_ant_fields))
+        self.sensor['Antennas/array/antenna'] = CategoricalData([array_ant], [0, self._ndumps])
+
     def _create_scans(self, ref_ant, dumps_def):
         """
         Setup reference antenna, as well as scans


### PR DESCRIPTION
Since ska-sa/katdal#252 the tests for katsdpcontim have been failing.
This is because the new method of calculating (u,v,w) coordinates
relies on an array reference antenna sensor which was not provided
by `MockDataset`. So we add a reference antenna in the same way
it is done in h5datav3 (i.e. use the first antenna as the array ref.).

Better than this will be to move `MockDataset` into `katdal` - but that
is a much larger task- so we do this for now to get katsdpcontim working
again.

@ludwigschwardt can you check that I did the copy/paste correctly ;)