### PR TITLE
Bump python-casacore to the newest version

### DIFF
--- a/katsdpimager/requirements.txt
+++ b/katsdpimager/requirements.txt
@@ -30,7 +30,7 @@ pycuda
 pyephem                   # via katpoint
 pygelf                    # via katsdpservices
 pytest                    # via pycuda
-python-casacore==3.0.0
+python-casacore==3.1.1
 python-dateutil           # via pandas, botocore
 python-lzf                # via katsdptelstate
 pytools                   # via pycuda


### PR DESCRIPTION
This version has a binary wheel that includes the casacore C libraries,
making it easier to install.