### PR TITLE
Change namespace of the 'refant' in telstate

### DIFF
--- a/katsdpcal/katsdpcal/reduction.py
+++ b/katsdpcal/katsdpcal/reduction.py
@@ -374,7 +374,7 @@ def shared_B_interp_nans(telstate, parameters, b_soln, st, et):
     return solutions.CalSolution('B', b_interp, b_soln.time)
 
 
-def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
+def pipeline(data, ts, parameters, solution_stores, stream_name, cal_name, sensors=None):
     """
     Pipeline calibration
 
@@ -391,6 +391,8 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
         Solution stores for the capture block, indexed by solution type
     stream_name : str
         Name of the L0 data stream
+    cal_name : str
+        Name of the cal output in telstate
     sensors : dict, optional
         Sensors available in the calling parent
 
@@ -416,6 +418,8 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
     # extract some some commonly used constants from the TS
 
     telstate_l0 = ts.view(stream_name)
+    telstate_cal = ts.view(cal_name)
+
     # solution intervals
     bp_solint = parameters['bp_solint']  # seconds
     k_solint = parameters['k_solint']  # seconds
@@ -515,7 +519,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 parameters['refant_index'] = best_refant_index
                 parameters['refant'] = parameters['antennas'][best_refant_index]
                 logger.info('Reference antenna set to %s', parameters['refant'].name)
-                ts['refant'] = parameters['refant'].description
+                telstate_cal['refant_index'] = parameters['refant_index']
                 s.refant = best_refant_index
 
         # run_t0 = time.time()

--- a/katsdpcal/katsdpcal/report.py
+++ b/katsdpcal/katsdpcal/report.py
@@ -1305,8 +1305,8 @@ def refant_antlabels(bls_lookup, refant_index, antenna_names):
 _lock = threading.Lock()
 
 
-def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, av_corr,
-                    st=None, et=None):
+def make_cal_report(ts, capture_block_id, stream_name, cal_name, parameters, report_path,
+                    av_corr, st=None, et=None):
     """
     Creates pdf calibration pipeline report (from RST source),
     using data from the Telescope State
@@ -1319,6 +1319,8 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
         capture block ID
     stream_name : str
         name of the L0 data stream
+    cal_name : str
+        name of the cal output in telstate
     parameters : dict
         Pipeline parameters
     report_path : str
@@ -1353,15 +1355,13 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             cal_rst.writeln('Stream: {}'.format(stream_name))
             cal_rst.writeln()
 
+            telstate_cal = ts.view(cal_name)
             # Obtain reference antenna selected by the pipeline
             refant_index = parameters['refant_index']
             if refant_index is None:
-                refant = ts.get('refant')
-                if refant is not None:
-                    refant = katpoint.Antenna(refant)
-                    refant_index = parameters['antenna_names'].index(refant.name)
-                    parameters['refant'] = refant
-                    parameters['refant_index'] = refant_index
+                refant_index = telstate_cal.get('refant_index')
+                parameters['refant'] = parameters['antennas'][refant_index]
+                parameters['refant_index'] = refant_index
 
             antennas = parameters['antennas']
             if av_corr:

--- a/katsdpcal/katsdpcal/test/test_control.py
+++ b/katsdpcal/katsdpcal/test/test_control.py
@@ -175,7 +175,7 @@ class ServerData:
         self.server = control.create_server(
             False, '127.0.0.1', 0, buffers,
             'sdp_l0test', testcase.l0_endpoints, None,
-            flags_streams, 1.0,
+            flags_streams, 1.0, 'cal',
             testcase.telstate_cal, self.parameters, self.report_path, self.log_path, None)
         self.client = None
         self.testcase = testcase
@@ -840,9 +840,9 @@ class TestCalDeviceServer(asynctest.TestCase):
             stream.send_heap(self.ig.get_end())
         await self.shutdown_servers(180)
         await self.assert_sensor_value('accumulator-capture-active', 0)
-        telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
-        refant_name = katpoint.Antenna(telstate_cb_cal['refant']).name
-        assert_not_equal(self.antennas[worst_index], refant_name)
+
+        refant_index = self.telstate_cal['refant_index']
+        assert_not_equal(worst_index, refant_index)
 
     def prepare_heaps(self, rs, n_times,
                       vis=None, weights=None, weights_channel=None, flags=None):

--- a/katsdpcal/scripts/run_cal.py
+++ b/katsdpcal/scripts/run_cal.py
@@ -371,7 +371,7 @@ def main():
     bokeh_kwargs = {'prefix': opts.dask_prefix}
     server = create_server(not opts.threading, opts.host, opts.port, buffers,
                            opts.l0_name, opts.l0_spead, l0_interface_address,
-                           opts.flags_streams, opts.clock_ratio,
+                           opts.flags_streams, opts.clock_ratio, opts.cal_name,
                            telstate_cal, parameters, opts.report_path, log_path, log_name,
                            opts.dask_diagnostics, bokeh_kwargs, opts.pipeline_profile,
                            opts.workers, opts.max_scans)


### PR DESCRIPTION
Store refant in the 'cal_' namespace instead of the 'cbid_cal_' namespace.
As the refant is set only once per sub-array and not once per capture block
it logically should be stored in the same namespace as all the other per sub-array
cal parameters. This changle also allows scripts such as `bf_phaseup.py` to read the refant
which will be required to apply the appropriate 'BCROSS_DIODE' and 'KCROSS_DIODe' solutions.

Additionally the 'refant' key is replaced/superceded by the 'refant_index' key, which now
only stores the index number of the reference antenna (instead of the whole antenna
description string)