### PR TITLE
Remove version pin for pyyaml as it apparently has a security vulnera…

### DIFF
--- a/katsdpcontim/katacomb/requirements.txt
+++ b/katsdpcontim/katacomb/requirements.txt
@@ -41,7 +41,7 @@ pytest == 3.3.2
 python-dateutil
 python-lzf
 pytz
-PyYAML == 3.13
+pyyaml
 rdbtools
 redis
 requests


### PR DESCRIPTION
…bility.

Rely on the pineed version in the base requirements instead.