### PR TITLE
Protect against potentially unset first_timestamp

### DIFF
--- a/katsdpcal/katsdpcal/control.py
+++ b/katsdpcal/katsdpcal/control.py
@@ -483,6 +483,10 @@ class Accumulator:
             bool
                 True if successful, False if we were interrupted by a force stop
             """
+            if self._first_timestamp is None:
+                telstate_cb_l0 = make_telstate_cb(self.owner.telstate_l0, self.capture_block_id) 
+                self._first_timestamp = telstate_cb_l0['first_timestamp']
+
             for idx in range(self._last_idx + 1, cur_idx + 1):
                 data_ts = self._first_timestamp + idx * self.owner.int_time + self.owner.sync_time
                 if self._obs_start is None:
@@ -599,7 +603,6 @@ class Accumulator:
 
             ig = spead2.ItemGroup()
             n_stop = 0                   # Number of stop heaps received
-            telstate_cb_l0 = make_telstate_cb(self.owner.telstate_l0, self.capture_block_id)
 
             # receive SPEAD stream
             self._logger.info('waiting to start accumulating data')
@@ -615,8 +618,6 @@ class Accumulator:
                     else:
                         continue
 
-                if self._first_timestamp is None:
-                    self._first_timestamp = telstate_cb_l0['first_timestamp']
                 # Convert from np.uint64, which behaves oddly
                 data_idx = int(ig['dump_index'].value)
                 if data_idx < self._last_idx:


### PR DESCRIPTION
It appears that under certain circumstances we can end up running _ensure_slots without self._first_timestamp being set correctly.

Seemingly this can happen when, either due to network or ingest failure, some of the split cal instances get data, but some don't (they receive on empty heap). In this scenario, cal will break out of the main while True in accumulate without setting first_timestamp.

If some of the cals have accumulated data, _ensure_slots will be called to try and extend the laggards resulting in an exception due to first_timestamp still being None.

The telstate entry used to get first_timestamp was only used for this, so moving it into _ensure_slots seemed practical.